### PR TITLE
Print debug info if SKA_HELPERS_VERSION_DEBUG env var set

### DIFF
--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -54,7 +54,10 @@ def get_version(package, distribution=None):
             git_dir = Path(dist_info.location, '.git')
             if git_dir.exists() and git_dir.is_dir():
                 raise AssertionError
-            print(f'** Using DIST_INFO ({package}, {distribution}):', dist_info.location)
+            if 'SKA_HELPERS_VERSION_DEBUG' in os.environ:
+                print(f'** Getting version via DIST_INFO: '
+                      f'package={package} distribution={distribution} '
+                      f'dist_info.location={dist_info.location}')
 
         except (DistributionNotFound, AssertionError):
             # Get_distribution failed or found a different package from this
@@ -66,8 +69,11 @@ def get_version(package, distribution=None):
             roots = ['..'] * len(package.split('.'))
             if os.path.basename(module.__file__) != '__init__.py':
                 roots = roots[:-1]
+            if 'SKA_HELPERS_VERSION_DEBUG' in os.environ:
+                print(f'** Getting version via setuptools_scm: '
+                      f'package={package} distribution={distribution} '
+                      f'get_version(root={Path(*roots)}, relative_to={module.__file__})')
             version = get_version(root=Path(*roots), relative_to=module.__file__)
-            print(f'** Using setuptools_scm ({package}, {distribution})')
 
     except Exception:
         # Something went wrong. The ``get_version` function should never block


### PR DESCRIPTION
## Testing

Without `SKA_HELPERS_VERSION_DEBUG` defined, then importing `ska_helpers` and `kadi` in the git repo happens with no chatter.

After `export SKA_HELPERS_VERSION_DEBUG=1`, then:
```
In [1]: import ska_helpers  # Within git repo
** Getting version via setuptools_scm: package=ska_helpers distribution=None get_version(root=.., relative_to=/Users/aldcroft/git/ska_helpers/ska_helpers/__init__.py)

In [2]: import kadi  # Installed py3-server branch that uses SCM for version
** Getting version via DIST_INFO: package=kadi distribution=None dist_info.location=/Users/aldcroft/miniconda3/envs/ska3-django2/lib/python3.6/site-packages

In [3]: import cheta  # Old-style with hard-coded version

In [4]:                                                                                                                      
```
I'm going to merge this right way to keep things rolling.  Any issues can be fixed in a subsequent PR.