### PR TITLE
should use __name__, not __package__

### DIFF
--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -20,7 +20,7 @@ def get_version(package, distribution=None):
     If the package is not from an installed distribution then get version from
     git using setuptools_scm.
 
-    :param package: package name, typically __package__
+    :param package: package name, typically __name__ (or __package__)
     :param distribution: name of distribution if different from ``package``
 
     :return: str


### PR DESCRIPTION
Modules that are not "packages" fail with ska_helpers version. These are only a few of the Ska.* modules, the ones that are not within its own directory and with an __init__.py file. In these cases one *has* to use __name__.

In all other cases, __package__ works as well as __name__.