### PR TITLE
when running testr, avoid emitting this warning

### DIFF
--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -82,8 +82,12 @@ def get_version(package, distribution=None):
         # import but generate a lot of output indicating the problem.
         import warnings
         import traceback
-        warnings.warn(traceback.format_exc() + '\n\n')
-        warnings.warn('Failed to find a package version, setting to 0.0.0')
+        if 'TESTR_FILE' not in os.environ:
+            # this avoids a test failure when checking log files with this warning.
+            # Pytest will import packages such as Ska.Shell first as Shell and then as Ska.Shell.
+            # https://docs.pytest.org/en/latest/pythonpath.html
+            warnings.warn(traceback.format_exc() + '\n\n')
+            warnings.warn('Failed to find a package version, setting to 0.0.0')
         version = '0.0.0'
 
     return version


### PR DESCRIPTION
## Description

This PR introduces changes to silence a warning ska_helpers.version emits whenever it can't figure out the version. In particular,  this warning is emitted during testr runs. The resulting warning is then misinterpreted as a failure.

Strictly speaking, the warning is correct, because pytest seems to be importing the  module incorrectly. It does that while climbing the directory tree until it finds the root of the package. In the end, it does the right import and everything is ok. At this point the warning was emitted already.

These are possible solutions:
1. silence the warning when a TESTR_ variable is in os.environ.
1. set a specific environment variable to silence this warning.
1. Modify the log parsing tests to correctly interpret and skip this warning.
1. have ska_helpers.version climb the directory tree to find its root.

This PR implements the first option. Second could also be. I would hesitate to implement the fourth.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing: runtestr passes when doing it on Ska.Shell.

Fixes #