### PR TITLE
get version without importing

### DIFF
--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -27,7 +27,7 @@ def get_version(package, distribution=None):
         Version string
     """
     # Get module file for package.
-    module_file = str(importlib.util.find_spec(package, distribution).origin)
+    module_file = importlib.util.find_spec(package, distribution).origin
 
     # From this point guarantee tha a version string is returned.
     try:

--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -26,10 +26,8 @@ def get_version(package, distribution=None):
     :return: str
         Version string
     """
-    # Get module for package.  When called from <package>/__init__.py this is
-    # not circular because that package is already in sys.modules.  If the
-    # package does not import then ImportError is raised as normal.
-    module = importlib.import_module(package)
+    # Get module file for package.
+    module_file = str(importlib.util.find_spec(package, distribution).origin)
 
     # From this point guarantee tha a version string is returned.
     try:
@@ -46,7 +44,7 @@ def get_version(package, distribution=None):
             # that does not have a <package>.egg-info directory, get_distribution()
             # will find an installed version.  Windows does not necessarily
             # respect the case so downcase everything.
-            assert module.__file__.lower().startswith(dist_info.location.lower())
+            assert module_file.lower().startswith(dist_info.location.lower())
 
             # If the dist_info.location appears to be a git repo, then
             # get_distribution() has gotten a "local" distribution and the
@@ -69,13 +67,13 @@ def get_version(package, distribution=None):
             # Define root as N directories up from location of __init__.py based
             # on package name.
             roots = ['..'] * len(package.split('.'))
-            if os.path.basename(module.__file__) != '__init__.py':
+            if os.path.basename(module_file) != '__init__.py':
                 roots = roots[:-1]
             if 'SKA_HELPERS_VERSION_DEBUG' in os.environ:
                 print(f'** Getting version via setuptools_scm: '
                       f'package={package} distribution={distribution} '
-                      f'get_version(root={Path(*roots)}, relative_to={module.__file__})')
-            version = get_version(root=Path(*roots), relative_to=module.__file__)
+                      f'get_version(root={Path(*roots)}, relative_to={module_file})')
+            version = get_version(root=Path(*roots), relative_to=module_file)
 
     except Exception:
         # Something went wrong. The ``get_version` function should never block


### PR DESCRIPTION
## Description

This removes a hack in version.get_version. Instead of importing a partially loaded module, use importlib.util.find_spec

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required), although the relevant parts are not tested.
- [x] Functional testing:
  - run `python setup.py --version` on a clean/dirty package git directory (without defining PYTHONPATH)
  - defined PYTHONPATH pointing to a dirty git directory, then `python -c 'import proseco; print(proseco.__version__)'`
  - running testr using this module, including a few other packages. Output seemed fine.

