### PR TITLE
Ignore useless warning about Ska being already imported

### DIFF
--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -10,7 +10,12 @@ import re
 import os
 from pathlib import Path
 import importlib
-from pkg_resources import get_distribution, DistributionNotFound
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', message=r'Module \w+ was already imported',
+                            category=UserWarning)
+    from pkg_resources import get_distribution, DistributionNotFound
 
 
 def get_version(package, distribution=None):


### PR DESCRIPTION
## Description

From within the source repo for a namespace package one gets a warning like below when importing:
```
In [1]: import Ska.Shell                                                                                
/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/ska_helpers/version.py:13: UserWarning:
 Module Ska was already imported from None, but /Users/aldcroft/git/Ska.Shell is being added to sys.path
```
## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

With the patch in place the warning goes away.
