### PR TITLE
Add ska_helpers.utils module with LazyDict

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ numpydoc_show_class_members = False
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
+    'sphinx.ext.viewcode',
     'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
@@ -92,8 +93,15 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
-
+html_theme = 'bootstrap-ska'
+html_theme_options = {
+    'logotext1': 'Ska! ',  # white,  semi-bold
+    'logotext2': 'ska_helpers',  # orange, light
+    'logotext3': '',   # white,  light
+    'homepage_url': 'https://sot.github.io/',
+    'homepage_text': 'ska',
+    'homepage_text_2': 'tools'
+}
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,13 +28,19 @@ from ska_helpers import __version__
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
+autosummary_generate = True
+
+# Don't show summaries of the members in each class along with the
+# class' docstring
+numpydoc_show_class_members = False
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.doctest',
-    'sphinx.ext.coverage']
+    'sphinx.ext.coverage',
+    'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -97,7 +103,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,12 @@ Ska Package Helpers
 .. automodule:: ska_helpers
    :members:
 
+Utilities
+
+.. automodule:: ska_helpers.utils
+   :members:
+
+
 Get Version
 -----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Ska Package Helpers
    :members:
 
 Utilities
+---------
 
 .. automodule:: ska_helpers.utils
    :members:

--- a/ska_helpers/run_info.py
+++ b/ska_helpers/run_info.py
@@ -19,10 +19,20 @@ __all__ = ['get_run_info', 'get_run_info_lines', 'log_run_info', '__version__']
 def get_run_info(opt=None, *, version=None, stack_level=1):
     """Get run time information as dict.
 
-    :param opt: argparse options
-    :param version: program version (default=__version__ in calling module)
-    :param stack_level: stack level for getting calling module
-    :returns: dict of information
+    Parameters
+    ----------
+    opt :
+        argparse options (Default value = None)
+    version :
+        program version (default=__version__ in calling module)
+    stack_level :
+        stack level for getting calling module (Default value = 1)
+
+    Returns
+    -------
+    dcit
+        run information
+
     """
     calling_frame_record = inspect.stack()[stack_level]
     calling_func_file = calling_frame_record[1]
@@ -43,10 +53,20 @@ def get_run_info(opt=None, *, version=None, stack_level=1):
 def get_run_info_lines(opt=None, *, version=None, stack_level=2):
     """Get run time information as formatted lines.
 
-    :param opt: argparse options
-    :param version: program version (default=__version__ in calling module)
-    :param stack_level: stack level for getting calling module
-    :returns: list of formatted information lines
+    Parameters
+    ----------
+    opt :
+        argparse options (Default value = None)
+    version :
+        program version (default=__version__ in calling module)
+    stack_level :
+        stack level for getting calling module (Default value = 2)
+
+    Returns
+    -------
+    list
+        formatted information lines
+
     """
     info = get_run_info(opt, version=version, stack_level=stack_level)
     info_lines = [
@@ -68,10 +88,16 @@ def log_run_info(log_func, opt=None, *, version=None, stack_level=3):
 
     Each formatted line is passed to ``log_func``.
 
-    :param log_func: logger output function (e.g. logger.info)
-    :param opt: argparse options
-    :param version: program version (default=__version__ in calling module)
-    :param stack_level: stack level for getting calling module
+    Parameters
+    ----------
+    log_func :
+        logger output function (e.g. logger.info)
+    opt :
+        argparse options (Default value = None)
+    version :
+        program version (default=__version__ in calling module)
+    stack_level :
+        stack level for getting calling module (Default value = 3)
     """
     info_lines = get_run_info_lines(opt, version=version, stack_level=stack_level)
     for line in info_lines:

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -34,11 +34,11 @@ def test_lazy_dict_pickle():
 
 def test_lazy_val():
     x = LazyVal(load_func, 1, 2, c=3)
-    xd = x.get()
+    xd = x.val
     assert xd == {'a': 1, 'b': 2, 'c': 3}
 
 
 def test_lazy_val_pickle():
     x = LazyVal(load_func, 1, 2, c=3)
     xpp = pickle.loads(pickle.dumps(x))
-    assert xpp.get() == {'a': 1, 'b': 2, 'c': 3}
+    assert xpp.val == {'a': 1, 'b': 2, 'c': 3}

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pickle
 
-from ska_helpers.utils import LazyDict
+from ska_helpers.utils import LazyDict, LazyVal
 
 
 def load_func(a, b, c=None):
@@ -26,7 +26,19 @@ def test_lazy_dict_basic():
     assert list(x.values()) == [1, 2, 3]
 
 
-def test_lazy_pickle():
+def test_lazy_dict_pickle():
     x = LazyDict(load_func, 1, 2, c=3)
     xpp = pickle.loads(pickle.dumps(x))
     assert xpp == x
+
+
+def test_lazy_val():
+    x = LazyVal(load_func, 1, 2, c=3)
+    xd = x.get()
+    assert xd == {'a': 1, 'b': 2, 'c': 3}
+
+
+def test_lazy_val_pickle():
+    x = LazyVal(load_func, 1, 2, c=3)
+    xpp = pickle.loads(pickle.dumps(x))
+    assert xpp.get() == {'a': 1, 'b': 2, 'c': 3}

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,0 +1,32 @@
+import pickle
+
+from ska_helpers.utils import LazyDict
+
+
+def load_func(a, b, c=None):
+    return {'a': a, 'b': b, 'c': c}
+
+
+def test_lazy_dict_basic():
+    x = LazyDict(load_func, 1, 2, c=3)
+    assert 'a' in x
+    assert 'b' in x
+    assert 'c' in x
+
+    x = LazyDict(load_func, 1, 2, c=3)
+    assert x == {'a': 1, 'b': 2, 'c': 3}
+
+    x = LazyDict(load_func, 1, 2, c=3)
+    assert len(x) == 3
+
+    x = LazyDict(load_func, 1, 2, c=3)
+    assert list(x) == ['a', 'b', 'c']
+
+    x = LazyDict(load_func, 1, 2, c=3)
+    assert list(x.values()) == [1, 2, 3]
+
+
+def test_lazy_pickle():
+    x = LazyDict(load_func, 1, 2, c=3)
+    xpp = pickle.loads(pickle.dumps(x))
+    assert xpp == x

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -11,6 +11,44 @@ def _lazy_load_wrap(unbound_method):
     return wrapper
 
 
+class LazyVal:
+    """Value which is lazy-initialized using supplied function ``load_func``.
+
+    This class allows defining a module-level value that is expensive to
+    initialize, where the initialization is done lazily (only when actually
+    needed).
+
+    The lazy value is accessed using the ``get`` method.
+
+    Parameters
+    ----------
+    load_func : function
+        Reference to a function that returns a dict to init this dict object
+    *args
+        Arguments list for ``load_func``
+    **kwargs
+        Keyword arguments for ``load_func``
+    """
+    def __init__(self, load_func, *args, **kwargs):
+        self._load_func = load_func
+        self._args = args
+        self._kwargs = kwargs
+        self._loaded = False
+        super().__init__()
+
+    def get(self):
+        if not self._loaded:
+            self.val = self._load_func(*self._args, **self._kwargs)
+            self._loaded = True
+
+            # Delete these so pickling always works (pickling a func can fail)
+            del self._load_func
+            del self._args
+            del self._kwargs
+
+        return self.val
+
+
 class LazyDict(dict):
     """Dict which is lazy-initialized using supplied function ``load_func``.
 

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -1,5 +1,7 @@
 import functools
 
+__all__ = ['LazyDict']
+
 
 def _lazy_load_wrap(unbound_method):
     @functools.wraps(unbound_method)
@@ -20,9 +22,9 @@ class LazyDict(dict):
     ----------
     load_func : function
         Reference to a function that returns a dict to init this dict object
-    *args : tuple
+    *args
         Arguments list for ``load_func``
-    **kwargs : dict
+    **kwargs
         Keyword arguments for ``load_func``
     """
     def __init__(self, load_func, *args, **kwargs):

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -1,0 +1,72 @@
+import functools
+
+
+def _lazy_load_wrap(unbound_method):
+    @functools.wraps(unbound_method)
+    def wrapper(self, *args, **kwargs):
+        self._load()
+        return unbound_method(self, *args, **kwargs)
+    return wrapper
+
+
+class LazyDict(dict):
+    """Dict which is lazy-initialized using supplied function ``load_func``.
+
+    This class allows defining a module-level dict that is expensive to
+    initialize, where the initialization is done lazily (only when actually
+    needed).
+
+    Parameters
+    ----------
+    load_func : function
+        Reference to a function that returns a dict to init this dict object
+    *args : tuple
+        Arguments list for ``load_func``
+    **kwargs : dict
+        Keyword arguments for ``load_func``
+    """
+    def __init__(self, load_func, *args, **kwargs):
+        self._load_func = load_func
+        self._args = args
+        self._kwargs = kwargs
+        self._loaded = False
+        super().__init__()
+
+    def _load(self):
+        if not self._loaded:
+            self.update(self._load_func(*self._args, **self._kwargs))
+            self._loaded = True
+
+            # Delete these so pickling always works (pickling a func can fail)
+            del self._load_func
+            del self._args
+            del self._kwargs
+
+    def __getitem__(self, item):
+        try:
+            return super().__getitem__(item)
+        except KeyError:
+            self._load()
+            return super().__getitem__(item)
+
+    __contains__ = _lazy_load_wrap(dict.__contains__)
+    __eq__ = _lazy_load_wrap(dict.__eq__)
+    __ge__ = _lazy_load_wrap(dict.__ge__)
+    __gt__ = _lazy_load_wrap(dict.__gt__)
+    __iter__ = _lazy_load_wrap(dict.__iter__)
+    __le__ = _lazy_load_wrap(dict.__le__)
+    __len__ = _lazy_load_wrap(dict.__len__)
+    __lt__ = _lazy_load_wrap(dict.__lt__)
+    __ne__ = _lazy_load_wrap(dict.__ne__)
+    __repr__ = _lazy_load_wrap(dict.__repr__)
+    __reversed__ = _lazy_load_wrap(dict.__reversed__)
+    __sizeof__ = _lazy_load_wrap(dict.__sizeof__)
+    __str__ = _lazy_load_wrap(dict.__str__)
+    copy = _lazy_load_wrap(dict.copy)
+    get = _lazy_load_wrap(dict.get)
+    items = _lazy_load_wrap(dict.items)
+    keys = _lazy_load_wrap(dict.keys)
+    pop = _lazy_load_wrap(dict.pop)
+    popitem = _lazy_load_wrap(dict.popitem)
+    setdefault = _lazy_load_wrap(dict.setdefault)
+    values = _lazy_load_wrap(dict.values)

--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -19,17 +19,23 @@ with warnings.catch_warnings():
 
 
 def get_version(package, distribution=None):
-    """
-    Get version string for ``package`` with optional ``distribution`` name.
+    """Get version string for ``package`` with optional ``distribution`` name.
 
     If the package is not from an installed distribution then get version from
     git using setuptools_scm.
 
-    :param package: package name, typically __package__
-    :param distribution: name of distribution if different from ``package``
+    Parameters
+    ----------
+    package :
+        package name, typically __package__
+    distribution :
+        name of distribution if different from ``package`` (Default value = None)
 
-    :return: str
+    Returns
+    -------
+    str
         Version string
+
     """
     # Get module file for package.
     module_file = importlib.util.find_spec(package, distribution).origin
@@ -97,12 +103,19 @@ def get_version(package, distribution=None):
 
 
 def parse_version(version):
-    """
-    Parse version string and return a dictionary with version information.
+    """Parse version string and return a dictionary with version information.
     This only handles the default scheme.
 
-    :param version: str
-    :return: dict
+    Parameters
+    ----------
+    version :
+        str
+
+    Returns
+    -------
+    dict
+        version information
+
     """
     fmt = r'(?P<major>[0-9]+)(.(?P<minor>[0-9]+))?(.(?P<patch>[0-9]+))?' \
           r'(.dev(?P<distance>[0-9]+))?'\


### PR DESCRIPTION
## Description

This adds a new module `ska_helpers.utils` as a generic drop box for Ska utilities that don't have a better home.

The first entry is the `LazyDict` class, which currently appears separately in Ska.engarchive and maude. This version is more complete/robust and somewhat tested.

This PR also converts the docstrings to numpydoc format.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [N/A] Functional testing
