### PR TITLE
add detail about all exceptions in ska_helpers.retry

### DIFF
--- a/ska_helpers/retry/__init__.py
+++ b/ska_helpers/retry/__init__.py
@@ -19,12 +19,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-__all__ = ['retry', 'retry_call']
+__all__ = ['retry', 'retry_call', 'RetryError']
 
 import logging
 from logging import StreamHandler
 
-from .api import retry, retry_call
+from .api import retry, retry_call, RetryError
 
 log = logging.getLogger(__name__)
 log.addHandler(StreamHandler())


### PR DESCRIPTION
## Description

One thing about the current `retry` function is that if it fails, it returns the last exception. While very often this is ok, because the error is due to a persistent exception, it is not always the case. In aca_view, I ended up writing code to keep track of all the exceptions, for debugging purposes (for example [here](https://github.com/sot/aca_view/blob/1350b38d7e40d56a2173eecf6123a273232d1747/aca_view/data_service/functions/maude_fetch.py#L40)).

This PR adds code to track all failures in the retry function and also adds one unit test. The failures are kept as a data member of the resulting `RetryError`. For each failure, we keep the type, its value and a stack trace as returned by the backtrace module.

If there is only one kind of exception, and always with the same message, then that exception is re-raised, so it works as one would expect.

## Testing

- [x] Passes unit tests on **MacOS**, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #