### PR TITLE
Add lru_cache_timed decorator

### DIFF
--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pickle
+import time
 
-from ska_helpers.utils import LazyDict, LazyVal
+from ska_helpers.utils import LazyDict, LazyVal, lru_cache_timed
 
 
 def load_func(a, b, c=None):
@@ -42,3 +43,23 @@ def test_lazy_val_pickle():
     x = LazyVal(load_func, 1, 2, c=3)
     xpp = pickle.loads(pickle.dumps(x))
     assert xpp.val == {'a': 1, 'b': 2, 'c': 3}
+
+
+def test_lru_cache_timed():
+    @lru_cache_timed(maxsize=128, timeout=0.1)
+    def test(a):
+        return a + 1
+
+    assert test.cache_info().currsize == 0
+    test(1)
+    assert test.cache_info().currsize == 1
+    time.sleep(0.11)
+    assert test.cache_info().currsize == 0
+    test(1)
+    assert test.cache_info().currsize == 1
+    time.sleep(0.11)
+    test(1)
+    test(2)
+    assert test.cache_info().currsize == 2
+    time.sleep(0.11)
+    assert test.cache_info().currsize == 0


### PR DESCRIPTION
## Description

This adds an LRU cache decorator where the cache expires after ``timeout`` seconds.

The inspiration is an issue with the cheta archive where the code below was stopping a persistent session from seeing new updates in the data.
```
@memoized
def get_interval(content, tstart, tstop):
    ...
```

An alternative is to install the entire `cachetools` package, which is available as a conda package in pkgs/main.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (new unit test)
