### PR TITLE
Add basic_logger utility

### DIFF
--- a/ska_helpers/logging.py
+++ b/ska_helpers/logging.py
@@ -1,0 +1,92 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+__all__ = ['basic_logger']
+
+
+def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs):
+    """Create logger ``name`` using logging.basicConfig.
+
+    This is a thin wrapper around logging.basicConfig, except:
+
+    - Uses logger named ``name`` instead of the root logger
+    - Defaults to a standard format for Ska applications. Specify
+      ``format=None`` to use the default ``basicConfig`` format.
+    - Not recommended for multithreaded or multiprocess applications due to
+      using a temporary monkey-patch of a global variable to create the logger.
+      It will probably work but it is not guaranteed.
+
+    This function does nothing if the ``name`` logger already has handlers
+    configured, unless the keyword argument *force* is set to ``True``.
+    It is a convenience method intended to do one-shot creation of a logger.
+
+    The default behaviour is to create a StreamHandler which writes to
+    ``sys.stderr``, set a formatter using the format string ``"%(asctime)s
+    %(funcName)s: %(message)s"``, and add the handler to the ``name`` logger
+    with a level of WARNING.
+
+    Example::
+
+      # In __init__.py for a package or in any module
+      from ska_helpers.logging import basic_logger
+      logger = basic_logger(__name__, level='INFO')
+
+      # In other submodules within a package the normal usage is to inherit
+      # the package logger.
+      import logging
+      logger = logging.getLogger(__name__)
+
+    A number of optional keyword arguments may be specified, which can alter
+    the default behaviour.
+
+    filename  Specifies that a FileHandler be created, using the specified
+              filename, rather than a StreamHandler.
+    filemode  Specifies the mode to open the file, if filename is specified
+              (if filemode is unspecified, it defaults to 'a').
+    format    Use the specified format string for the handler.
+    datefmt   Use the specified date/time format.
+    style     If a format string is specified, use this to specify the
+              type of format string (possible values '%', '{', '$', for
+              %-formatting, :meth:`str.format` and :class:`string.Template`
+              - defaults to '%').
+    level     Set the ``name`` logger level to the specified level. This can be
+              a number (10, 20, ...) or a string ('NOTSET', 'DEBUG', 'INFO',
+              'WARNING', 'ERROR', 'CRITICAL') or ``logging.DEBUG``, etc.
+    stream    Use the specified stream to initialize the StreamHandler. Note
+              that this argument is incompatible with 'filename' - if both
+              are present, 'stream' is ignored.
+    handlers  If specified, this should be an iterable of already created
+              handlers, which will be added to the ``name`` handler. Any handler
+              in the list which does not have a formatter assigned will be
+              assigned the formatter created in this function.
+    force     If this keyword  is specified as true, any existing handlers
+              attached to the ``name`` logger are removed and closed, before
+              carrying out the configuration as specified by the other
+              arguments.
+    Note that you could specify a stream created using open(filename, mode)
+    rather than passing the filename and mode in. However, it should be
+    remembered that StreamHandler does not close its stream (since it may be
+    using sys.stdout or sys.stderr), whereas FileHandler closes its stream
+    when the handler is closed.
+
+    Note this function is probably not thread-safe.
+
+    :param name: str, logger name
+    :param format: str, format string for handler
+    :param **kwargs: other keyword arguments for logging.basicConfig
+    :returns: Logger object
+    """
+    import logging
+
+    if format is not None:
+        kwargs['format'] = format
+    logger = logging.getLogger(name)
+
+    # Monkeypatch logging temporarily and configure our logger
+    root = logging.root
+    try:
+        logging.root = logger
+        logging.basicConfig(**kwargs)
+    finally:
+        logging.root = root
+
+    return logger

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -1,6 +1,6 @@
 import functools
 
-__all__ = ['LazyDict', 'LazyVal']
+__all__ = ['LazyDict', 'LazyVal', 'basic_logger']
 
 
 def _lazy_load_wrap(unbound_method):
@@ -192,3 +192,89 @@ def lru_cache_timed(maxsize=128, typed=False, timeout=3600):
         _wrapped.cache_clear = func.cache_clear
         return _wrapped
     return _wrapper
+
+
+def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs):
+    """Create logger ``name`` using logging.basicConfig.
+
+    This is a thin wrapper around logging.basicConfig, except:
+
+    - Uses logger named ``name`` instead of the root logger
+    - Defaults to a standard format for Ska applications. Specify
+      ``format=None`` to use the default ``basicConfig`` format.
+
+    This function does nothing if the ``name`` logger already has handlers
+    configured, unless the keyword argument *force* is set to ``True``.
+    It is a convenience method intended to do one-shot creation of a logger.
+
+    The default behaviour is to create a StreamHandler which writes to
+    ``sys.stderr``, set a formatter using the format string ``"%(asctime)s
+    %(funcName)s: %(message)s"``, and add the handler to the ``name`` logger
+    with a level of WARNING.
+
+    Example::
+
+      # In __init__.py for a package or in any module
+      from ska_helpers.utils import basic_logger
+      logger = basic_logger(__name__, level='INFO')
+
+      # In other submodules within a package the normal usage is to inherit
+      # the package logger.
+      import logging
+      logger = logging.getLogger(__name__)
+
+    A number of optional keyword arguments may be specified, which can alter
+    the default behaviour.
+
+    filename  Specifies that a FileHandler be created, using the specified
+              filename, rather than a StreamHandler.
+    filemode  Specifies the mode to open the file, if filename is specified
+              (if filemode is unspecified, it defaults to 'a').
+    format    Use the specified format string for the handler.
+    datefmt   Use the specified date/time format.
+    style     If a format string is specified, use this to specify the
+              type of format string (possible values '%', '{', '$', for
+              %-formatting, :meth:`str.format` and :class:`string.Template`
+              - defaults to '%').
+    level     Set the ``name`` logger level to the specified level. This can be
+              a number (10, 20, ...) or a string ('NOTSET', 'DEBUG', 'INFO',
+              'WARNING', 'ERROR', 'CRITICAL') or ``logging.DEBUG``, etc.
+    stream    Use the specified stream to initialize the StreamHandler. Note
+              that this argument is incompatible with 'filename' - if both
+              are present, 'stream' is ignored.
+    handlers  If specified, this should be an iterable of already created
+              handlers, which will be added to the ``name`` handler. Any handler
+              in the list which does not have a formatter assigned will be
+              assigned the formatter created in this function.
+    force     If this keyword  is specified as true, any existing handlers
+              attached to the ``name`` logger are removed and closed, before
+              carrying out the configuration as specified by the other
+              arguments.
+    Note that you could specify a stream created using open(filename, mode)
+    rather than passing the filename and mode in. However, it should be
+    remembered that StreamHandler does not close its stream (since it may be
+    using sys.stdout or sys.stderr), whereas FileHandler closes its stream
+    when the handler is closed.
+
+    Note this function is probably not thread-safe.
+
+    :param name: str, logger name
+    :param format: str, format string for handler
+    :param **kwargs: other keyword arguments for logging.basicConfig
+    :returns: Logger object
+    """
+    import logging
+
+    if format is not None:
+        kwargs['format'] = format
+    logger = logging.getLogger(name)
+
+    # Monkeypatch logging temporarily and configure our logger
+    root = logging.root
+    try:
+        logging.root = logger
+        logging.basicConfig(**kwargs)
+    finally:
+        logging.root = root
+
+    return logger

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -1,6 +1,8 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
 import functools
 
-__all__ = ['LazyDict', 'LazyVal', 'basic_logger']
+__all__ = ['LazyDict', 'LazyVal']
 
 
 def _lazy_load_wrap(unbound_method):
@@ -192,89 +194,3 @@ def lru_cache_timed(maxsize=128, typed=False, timeout=3600):
         _wrapped.cache_clear = func.cache_clear
         return _wrapped
     return _wrapper
-
-
-def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs):
-    """Create logger ``name`` using logging.basicConfig.
-
-    This is a thin wrapper around logging.basicConfig, except:
-
-    - Uses logger named ``name`` instead of the root logger
-    - Defaults to a standard format for Ska applications. Specify
-      ``format=None`` to use the default ``basicConfig`` format.
-
-    This function does nothing if the ``name`` logger already has handlers
-    configured, unless the keyword argument *force* is set to ``True``.
-    It is a convenience method intended to do one-shot creation of a logger.
-
-    The default behaviour is to create a StreamHandler which writes to
-    ``sys.stderr``, set a formatter using the format string ``"%(asctime)s
-    %(funcName)s: %(message)s"``, and add the handler to the ``name`` logger
-    with a level of WARNING.
-
-    Example::
-
-      # In __init__.py for a package or in any module
-      from ska_helpers.utils import basic_logger
-      logger = basic_logger(__name__, level='INFO')
-
-      # In other submodules within a package the normal usage is to inherit
-      # the package logger.
-      import logging
-      logger = logging.getLogger(__name__)
-
-    A number of optional keyword arguments may be specified, which can alter
-    the default behaviour.
-
-    filename  Specifies that a FileHandler be created, using the specified
-              filename, rather than a StreamHandler.
-    filemode  Specifies the mode to open the file, if filename is specified
-              (if filemode is unspecified, it defaults to 'a').
-    format    Use the specified format string for the handler.
-    datefmt   Use the specified date/time format.
-    style     If a format string is specified, use this to specify the
-              type of format string (possible values '%', '{', '$', for
-              %-formatting, :meth:`str.format` and :class:`string.Template`
-              - defaults to '%').
-    level     Set the ``name`` logger level to the specified level. This can be
-              a number (10, 20, ...) or a string ('NOTSET', 'DEBUG', 'INFO',
-              'WARNING', 'ERROR', 'CRITICAL') or ``logging.DEBUG``, etc.
-    stream    Use the specified stream to initialize the StreamHandler. Note
-              that this argument is incompatible with 'filename' - if both
-              are present, 'stream' is ignored.
-    handlers  If specified, this should be an iterable of already created
-              handlers, which will be added to the ``name`` handler. Any handler
-              in the list which does not have a formatter assigned will be
-              assigned the formatter created in this function.
-    force     If this keyword  is specified as true, any existing handlers
-              attached to the ``name`` logger are removed and closed, before
-              carrying out the configuration as specified by the other
-              arguments.
-    Note that you could specify a stream created using open(filename, mode)
-    rather than passing the filename and mode in. However, it should be
-    remembered that StreamHandler does not close its stream (since it may be
-    using sys.stdout or sys.stderr), whereas FileHandler closes its stream
-    when the handler is closed.
-
-    Note this function is probably not thread-safe.
-
-    :param name: str, logger name
-    :param format: str, format string for handler
-    :param **kwargs: other keyword arguments for logging.basicConfig
-    :returns: Logger object
-    """
-    import logging
-
-    if format is not None:
-        kwargs['format'] = format
-    logger = logging.getLogger(name)
-
-    # Monkeypatch logging temporarily and configure our logger
-    root = logging.root
-    try:
-        logging.root = logger
-        logging.basicConfig(**kwargs)
-    finally:
-        logging.root = root
-
-    return logger


### PR DESCRIPTION
## Description

This implements a thin wrapper around `logging.basicConfig`, addressing the show-stopper that `basicConfig` only configures the root logger.

I copied the `basicConfig` docs and then customized/enhanced them a bit.

@javierggt - what do you think? It's a bit of a hack but maybe works for us?

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
In [1]: from ska_helpers.logging import basic_logger

In [2]: logger = basic_logger('me')

In [3]: logger.info('asdf')

In [5]: logger.warning('asdf')
2022-06-09 07:15:47,349 <module>: asdf

In [6]: logger = basic_logger('me', level='INFO')

In [7]: logger.info('asdf')

In [8]: logger = basic_logger('me', level='INFO', force=True)

In [9]: logger.info('asdf')
2022-06-09 07:16:25,243 <module>: asdf

In [10]: logger = basic_logger('me', level='INFO', force=True, format=None)

In [11]: logger.info('asdf')
INFO:me:asdf
```
