### PR TITLE
bugfix: do not configure logger if it has a handler or log-level is set

### DIFF
--- a/ska_helpers/logging.py
+++ b/ska_helpers/logging.py
@@ -81,6 +81,9 @@ def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs)
         kwargs['format'] = format
     logger = logging.getLogger(name)
 
+    if not kwargs.get('force', False) and (logger.hasHandlers() or logger.level != logging.NOTSET):
+      return logger
+
     # Monkeypatch logging temporarily and configure our logger
     root = logging.root
     try:


### PR DESCRIPTION
## Description

This PR is to prevent `logging.basic_logger` from modifying a logger that is already configured.

Fixes #24

## Interface impacts
None

## Testing

### Unit tests
- [ ] No unit tests

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

I ran the examples in /issues/24
