### PR TITLE
Improve get_version debug output and fully test functionality

### DIFF
--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -38,8 +38,19 @@ def get_version(package, distribution=None):
         Version string
 
     """
+    import sys
+
+    debug = "SKA_HELPERS_VERSION_DEBUG" in os.environ
+    if debug:
+        print("*" * 80)
+        print(f"Getting version for package={package} distribution={distribution} ")
+        print(f"  Current directory: {Path.cwd()}")
+        print(f"  {sys.path=}")
+
     # Get module file for package.
     module_file = importlib.util.find_spec(package, distribution).origin
+    if debug:
+        print(f"  {module_file=}")
 
     # From this point guarantee tha a version string is returned.
     try:
@@ -48,15 +59,32 @@ def get_version(package, distribution=None):
             # # that gets imported (we check that next).  For some packages, e.g.
             # cheta or pyyaml, the distribution will be different from the
             # package.
+            if debug:
+                print(
+                    "  Getting distribution "
+                    f"dist_info=get_distribution({distribution or package})"
+                )
             dist_info = get_distribution(distribution or package)
             version = dist_info.version
+            if debug:
+                print(f"    {dist_info.location=}")
+                print(f"    {dist_info.version=}")
 
             # Check if the imported package __init__.py file has the same location
             # as the distribution that was found.  If working in a local git repo
             # that does not have a <package>.egg-info directory, get_distribution()
             # will find an installed version.  Windows does not necessarily
             # respect the case so downcase everything.
-            assert module_file.lower().startswith(dist_info.location.lower())
+            ok = module_file.lower().startswith(dist_info.location.lower())
+            if debug:
+                if ok:
+                    print("    distinfo.location matches module_file")
+                else:
+                    print(
+                        "    FAIL: distinfo.location does not match module_file, "
+                        "falling through to setuptools_scm"
+                    )
+            assert ok
 
             # If the dist_info.location appears to be a git repo, then
             # get_distribution() has gotten a "local" distribution and the
@@ -64,31 +92,35 @@ def get_version(package, distribution=None):
             # last run of "setup.py sdist" or "setup.py bdist_wheel", i.e.
             # unrelated to current version, so ignore in this case.
             git_dir = Path(dist_info.location, ".git")
-            if git_dir.exists() and git_dir.is_dir():
-                raise AssertionError
-            if "SKA_HELPERS_VERSION_DEBUG" in os.environ:
-                print(
-                    "** Getting version via DIST_INFO: "
-                    f"package={package} distribution={distribution} "
-                    f"dist_info.location={dist_info.location}"
-                )
+            bad = git_dir.exists() and git_dir.is_dir()
+            if debug:
+                if bad:
+                    print(
+                        "    FAIL: distinfo.location is git repo (version likely wrong), "
+                        "falling through to setuptools_scm"
+                    )
+                else:
+                    print("    distinfo.location looks OK (not a git repo)")
+            assert not bad
 
         except (DistributionNotFound, AssertionError):
             # Get_distribution failed or found a different package from this
             # file, try getting version from source repo.
             from setuptools_scm import get_version
 
+            if debug:
+                print("  Getting version via setuptools_scm for git repo")
+
             # Define root as N directories up from location of __init__.py based
             # on package name.
             roots = [".."] * len(package.split("."))
             if os.path.basename(module_file) != "__init__.py":
                 roots = roots[:-1]
-            if "SKA_HELPERS_VERSION_DEBUG" in os.environ:
-                print(
-                    "** Getting version via setuptools_scm: "
-                    f"package={package} distribution={distribution} "
-                    f"get_version(root={Path(*roots)}, relative_to={module_file})"
-                )
+            if debug:
+                print(f"    Running get_version(")
+                print(f"        root={Path(*roots)},")
+                print(f"        relative_to={module_file}")
+                print(f"    )")
             version = get_version(root=Path(*roots), relative_to=module_file)
 
     except Exception:
@@ -103,7 +135,19 @@ def get_version(package, distribution=None):
             # https://docs.pytest.org/en/latest/pythonpath.html
             warnings.warn(traceback.format_exc() + "\n\n")
             warnings.warn("Failed to find a package version, setting to 0.0.0")
+
         version = "0.0.0"
+
+        if debug:
+            print(f"FAIL: got {version=}")
+
+    else:
+        # No exception, so we got a valid version string.
+        if debug:
+            print(f"SUCCESS: got {version=}")
+
+    if debug:
+        print("*" * 80)
 
     return version
 

--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -101,7 +101,7 @@ def get_version(package, distribution=None):
                 log("    distinfo.location matches module_file")
             else:
                 log(
-                    "    FAIL: distinfo.location does not match module_file, "
+                    "    WARNING: distinfo.location does not match module_file, "
                     "falling through to setuptools_scm"
                 )
             assert ok
@@ -115,7 +115,7 @@ def get_version(package, distribution=None):
             bad = git_dir.exists() and git_dir.is_dir()
             if bad:
                 log(
-                    "    FAIL: distinfo.location is git repo (version likely wrong), "
+                    "    WARNING: distinfo.location is git repo (version likely wrong), "
                     "falling through to setuptools_scm"
                 )
             else:
@@ -147,7 +147,7 @@ def get_version(package, distribution=None):
         import warnings
 
         version = "0.0.0"
-        log(f"FAIL: got {version=}")
+        log(f"WARNING: got {version=}")
         log("*" * 80)
 
         if "TESTR_FILE" not in os.environ:


### PR DESCRIPTION
## Description

This PR substantially improves the debug output for `get_version()`. This was inspired by issues with pytest, in particular getting unexpected failures to get the package version within pytest when PYTHONPATH was set.

As part of this I tried to do functional testing that fully covers the code.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None, debug info still printed to STDOUT.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

## Functional testing

All testing done in a dev Ska3 environment within the `ska_helpers` git repo root
directory. Non-release installed packages are expected in this development env.

### Debug output disabled (default)
Confirm no extraneous output and expected versions.

#### Normal installed package
```
$ python -c 'from ska_helpers.version import get_version; print(get_version("acdc"))'
4.9.0
```
#### Git repo has a *.egg-info file that provides a possibly-wrong version
```
$ python -c 'from ska_helpers.version import get_version; print(get_version("ska_helpers"))'
0.7.1.dev10+gf4f35a1
```
#### Success for a namespace package with correct distribution supplied
```
$ python -c 'from ska_helpers.version import get_version; print(get_version("Chandra.Time", "chandra_time"))'
4.0.2.dev8+gdd9107e
```

### Debug output enabled

`export SKA_HELPERS_VERSION_DEBUG=1`

#### Normal installed package
```
$ python -c 'from ska_helpers.version import get_version; get_version("acdc")'  
********************************************************************************
Getting version for package=acdc distribution=None
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/acdc/__init__.py'
  Getting distribution dist_info=get_distribution(acdc)
    dist_info.location='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages'
    dist_info.version='4.9.0'
    distinfo.location matches module_file
    distinfo.location looks OK (not a git repo)
SUCCESS: got version='4.9.0'
********************************************************************************
```

#### Git repo has a *.egg-info file that provides a possibly-wrong version
```
$ python -c 'from ska_helpers.version import get_version)'
********************************************************************************
Getting version for package=ska_helpers distribution=None
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/git/ska_helpers/ska_helpers/__init__.py'
  Getting distribution dist_info=get_distribution(ska_helpers)
    dist_info.location='/Users/aldcroft/git/ska_helpers'
    dist_info.version='0.7.1.dev9+ge23a207.d20221224'      <<== WRONG
    distinfo.location matches module_file
    FAIL: distinfo.location is git repo (version likely wrong), falling through to setuptools_scm
  Getting version via setuptools_scm for git repo
    Running get_version(
        root=..,
        relative_to=/Users/aldcroft/git/ska_helpers/ska_helpers/__init__.py
    )
SUCCESS: got version='0.7.1.dev10+gf4f35a1'
********************************************************************************
```

#### Success for a namespace package with correct distribution supplied
```
$ python -c 'from ska_helpers.version import get_version; get_version("Chandra.Time", "chandra_time")'
********************************************************************************
Getting version for package=Chandra.Time distribution=chandra_time
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/Chandra/Time/__init__.py'
  Getting distribution dist_info=get_distribution(chandra_time)
    dist_info.location='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages'
    dist_info.version='4.0.2.dev8+gdd9107e'
    distinfo.location matches module_file
    distinfo.location looks OK (not a git repo)
SUCCESS: got version='4.0.2.dev8+gdd9107e'
********************************************************************************
```

#### Fail for a namespace package with no distribution supplied
```
$ python -c 'from ska_helpers.version import get_version; get_version("Chandra.Time")'
********************************************************************************
Getting version for package=Chandra.Time distribution=None
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/Chandra/Time/__init__.py'
  Getting distribution dist_info=get_distribution(Chandra.Time)
  Getting version via setuptools_scm for git repo
    Running get_version(
        root=../..,
        relative_to=/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/Chandra/Time/__init__.py
    )
/Users/aldcroft/git/ska_helpers/ska_helpers/version.py:136: UserWarning: Traceback (most recent call last):
  File "/Users/aldcroft/git/ska_helpers/ska_helpers/version.py", line 67, in get_version
    dist_info = get_distribution(distribution or package)
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/pkg_resources/__init__.py", line 466, in get_distribution
    dist = get_provider(dist)
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/pkg_resources/__init__.py", line 342, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/pkg_resources/__init__.py", line 886, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/pkg_resources/__init__.py", line 772, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'Chandra.Time' distribution was not found and is required by the application

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/aldcroft/git/ska_helpers/ska_helpers/version.py", line 124, in get_version
    version = get_version(root=Path(*roots), relative_to=module_file)
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/setuptools_scm/__init__.py", line 173, in get_version
    return _get_version(config)
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/setuptools_scm/__init__.py", line 177, in _get_version
    parsed_version = _do_parse(config)
  File "/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/setuptools_scm/__init__.py", line 135, in _do_parse
    raise LookupError(
LookupError: setuptools-scm was unable to detect version for '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages'.

Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj

  warnings.warn(traceback.format_exc() + "\n\n")
/Users/aldcroft/git/ska_helpers/ska_helpers/version.py:137: UserWarning: Failed to find a package version, setting to 0.0.0
  warnings.warn("Failed to find a package version, setting to 0.0.0")
FAIL: got version='0.0.0'
********************************************************************************
********************************************************************************
Getting version for package=Chandra.Time distribution=None 
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/Chandra/Time/__init__.py'
  Getting distribution dist_info=get_distribution(Chandra.Time)
  Getting version via setuptools_scm for git repo
    Running get_version(
        root=../..,
        relative_to=/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages/Chandra/Time/__init__.py
    )
FAIL: got version='0.0.0'
********************************************************************************
```

#### Normal package in git repo with PYTHONPATH set and egg-info dir
In this case there is a pre-existing egg-info directory.
```
$ env PYTHONPATH="/Users/aldcroft/git/chandra_aca" \
  python -c 'from ska_helpers.version import get_version; get_version("chandra_aca")'

********************************************************************************
Getting version for package=chandra_aca distribution=None
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/git/chandra_aca', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/git/chandra_aca/chandra_aca/__init__.py'
  Getting distribution dist_info=get_distribution(chandra_aca)
    dist_info.location='/Users/aldcroft/git/chandra_aca'
    dist_info.version='4.37.2.dev4+gfd8187b'
    distinfo.location matches module_file
    FAIL: distinfo.location is git repo (version likely wrong), falling through to setuptools_scm
  Getting version via setuptools_scm for git repo
    Running get_version(
        root=..,
        relative_to=/Users/aldcroft/git/chandra_aca/chandra_aca/__init__.py
    )
SUCCESS: got version='4.37.2.dev5+gcbf66c8.d20221224'
********************************************************************************
```
#### Normal package in git repo with PYTHONPATH set and no egg-info dir
```
$ rm -rf ~/git/chandra_aca/chandra_aca.egg-info
$ env PYTHONPATH="/Users/aldcroft/git/chandra_aca" \
  python -c 'from ska_helpers.version import get_version; get_version("chandra_aca")'
********************************************************************************
Getting version for package=chandra_aca distribution=None
  Current directory: /Users/aldcroft/git/ska_helpers
  sys.path=['', '/Users/aldcroft/git/chandra_aca', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python38.zip', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/lib-dynload', '/Users/aldcroft/.local/lib/python3.8/site-packages', '/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages', '/Users/aldcroft/git/ska_helpers']
  module_file='/Users/aldcroft/git/chandra_aca/chandra_aca/__init__.py'
  Getting distribution dist_info=get_distribution(chandra_aca)
    dist_info.location='/Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.8/site-packages'
    dist_info.version='4.37.2.dev4+gfd8187b'
    FAIL: distinfo.location does not match module_file, falling through to setuptools_scm
  Getting version via setuptools_scm for git repo
    Running get_version(
        root=..,
        relative_to=/Users/aldcroft/git/chandra_aca/chandra_aca/__init__.py
    )
SUCCESS: got version='4.37.2.dev5+gcbf66c8.d20221224'
********************************************************************************
```
