### PR TITLE
Add environment module with new function configure_ska_environment()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,13 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.10
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
-      - id: isort
-        name: isort (python)
+    - id: isort
+      name: isort (python)
+      language_version: python3.10

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,13 @@ Chandra Models Data
 .. automodule:: ska_helpers.chandra_models
    :members:
 
+Environment
+-----------
+
+.. automodule:: ska_helpers.environment
+   :members:
+
+
 Logging
 -------
 

--- a/ska_helpers/environment.py
+++ b/ska_helpers/environment.py
@@ -5,8 +5,10 @@ runtime environment at the point of import of every Ska3 package.
 """
 
 import os
+from functools import cache
 
 
+@cache
 def configure_ska_environment():
     """Configure environment for Ska3 runtime.
 

--- a/ska_helpers/environment.py
+++ b/ska_helpers/environment.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+The ``ska_helpers.environment`` module provides a function to configure the Ska3
+runtime environment at the point of import of every Ska3 package.
+"""
+
+import os
+
+
+def configure_ska_environment():
+    """Configure environment for Ska3 runtime.
+
+    This is called by ska_helpers.version.get_version() and thus gets called
+    upon import of every Ska3 package.
+
+    This includes setting NUMBA_CACHE_DIR to $HOME/.ska3/cache/numba if that env
+    var is not already defined.  This is to avoid problems with read-only
+    filesystems.
+    """
+    # If not already defined, set NUMBA_CACHE_DIR to a writable directory in the
+    # user's home directory $HOME/.ska3/cache/numba. The numba default is to put
+    # files into the package distribution directory, which is read-only on Ska3
+    # on HEAD and GRETA. Note that numba will create this directory if it does exist,
+    # potentially including subdirectories.
+    numba_cache_dir = os.path.join(os.path.expanduser("~"), ".ska3", "cache", "numba")
+    os.environ.setdefault("NUMBA_CACHE_DIR", numba_cache_dir)

--- a/ska_helpers/logging.py
+++ b/ska_helpers/logging.py
@@ -46,38 +46,45 @@ def basic_logger(
     A number of optional keyword arguments may be specified, which can alter
     the default behaviour.
 
-    filename  Specifies that a FileHandler be created, using the specified
-              filename, rather than a StreamHandler.
+    filename
+        Specifies that a FileHandler be created, using the specified filename,
+        rather than a StreamHandler.
 
-    filemode  Specifies the mode to open the file, if filename is specified
-              (if filemode is unspecified, it defaults to 'a').
+    filemode
+        Specifies the mode to open the file, if filename is specified (if
+        filemode is unspecified, it defaults to 'a').
 
-    format    Use the specified format string for the handler.
+    format
+        Use the specified format string for the handler.
 
-    datefmt   Use the specified date/time format.
+    datefmt
+        Use the specified date/time format.
 
-    style     If a format string is specified, use this to specify the
-              type of format string (possible values '%', '{', '$', for
-              %-formatting, :meth:`str.format` and :class:`string.Template`
-              - defaults to '%').
+    style
+        If a format string is specified, use this to specify the type of format
+        string (possible values '%', '{', '$', for %-formatting,
+        :meth:`str.format` and :class:`string.Template` - defaults to '%').
 
-    level     Set the ``name`` logger level to the specified level. This can be
-              a number (10, 20, ...) or a string ('NOTSET', 'DEBUG', 'INFO',
-              'WARNING', 'ERROR', 'CRITICAL') or ``logging.DEBUG``, etc.
+    level
+        Set the ``name`` logger level to the specified level. This can be a
+        number (10, 20, ...) or a string ('NOTSET', 'DEBUG', 'INFO', 'WARNING',
+        'ERROR', 'CRITICAL') or ``logging.DEBUG``, etc.
 
-    stream    Use the specified stream to initialize the StreamHandler. Note
-              that this argument is incompatible with 'filename' - if both
-              are present, 'stream' is ignored.
+    stream
+        Use the specified stream to initialize the StreamHandler. Note that this
+        argument is incompatible with 'filename' - if both are present, 'stream'
+        is ignored.
 
-    handlers  If specified, this should be an iterable of already created
-              handlers, which will be added to the ``name`` handler. Any handler
-              in the list which does not have a formatter assigned will be
-              assigned the formatter created in this function.
+    handlers
+        If specified, this should be an iterable of already created handlers,
+        which will be added to the ``name`` handler. Any handler in the list
+        which does not have a formatter assigned will be assigned the formatter
+        created in this function.
 
-    force     If this keyword  is specified as true, any existing handlers
-              attached to the ``name`` logger are removed and closed, before
-              carrying out the configuration as specified by the other
-              arguments.
+    force
+        If this keyword  is specified as true, any existing handlers attached to
+        the ``name`` logger are removed and closed, before carrying out the
+        configuration as specified by the other arguments.
 
     Note that you could specify a stream created using open(filename, mode)
     rather than passing the filename and mode in. However, it should be

--- a/ska_helpers/retry/__init__.py
+++ b/ska_helpers/retry/__init__.py
@@ -3,21 +3,21 @@ Retry package initially copied from https://github.com/invl/retry.
 
 This project appears to be abandoned so moving it to ska_helpers.
 
-LICENSE:
+LICENSE::
 
-Copyright 2014 invl
+    Copyright 2014 invl
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 """
 __all__ = ["retry", "retry_call", "RetryError", "tables_open_file"]
 

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -186,7 +186,7 @@ def retry_call(
 
 
 def tables_open_file(*args, **kwargs):
-    """Call tables.open_file(*args, **kwargs) with retry up to 3 times.
+    """Call ``tables.open_file(*args, **kwargs)`` with retry up to 3 times.
 
     This only catches tables.exceptions.HDF5ExtError. After an initial failure
     it will try again after 2 seconds and once more after 4 seconds.

--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -15,6 +15,7 @@ import warnings
 from pathlib import Path
 
 from ska_helpers.logging import basic_logger
+
 from .environment import configure_ska_environment
 
 with warnings.catch_warnings():
@@ -76,7 +77,7 @@ def get_version(package, distribution=None):
     log(f"Getting version for package={package} distribution={distribution} ")
     log(f"  Current directory: {Path.cwd()}")
     log(f"  {sys.path=}")
-    
+
     # Get module file for package.
     module_file = importlib.util.find_spec(package, distribution).origin
     log(f"  {module_file=}")

--- a/ska_helpers/version.py
+++ b/ska_helpers/version.py
@@ -15,6 +15,7 @@ import warnings
 from pathlib import Path
 
 from ska_helpers.logging import basic_logger
+from .environment import configure_ska_environment
 
 with warnings.catch_warnings():
     warnings.filterwarnings(
@@ -61,6 +62,11 @@ def get_version(package, distribution=None):
     """
     import sys
 
+    # Configure environment for Ska3 runtime. This is a bit of a hack but get_version()
+    # is a convenient place to do this because it is called by every Ska3 package
+    # on import.
+    configure_ska_environment()
+
     level_stdout = "DEBUG" if "SKA_HELPERS_VERSION_DEBUG" in os.environ else "INFO"
     level_string = "DEBUG"
     logger, logger_string = get_version_logger(level_stdout, level_string)
@@ -70,7 +76,7 @@ def get_version(package, distribution=None):
     log(f"Getting version for package={package} distribution={distribution} ")
     log(f"  Current directory: {Path.cwd()}")
     log(f"  {sys.path=}")
-
+    
     # Get module file for package.
     module_file = importlib.util.find_spec(package, distribution).origin
     log(f"  {module_file=}")


### PR DESCRIPTION
## Description

This PR adds a bit of infrastructure to allow on-the-fly configuration of the Ska environment (notably setting environment variables). This is done in a new sub-module `environment` via the function` configure_ska_environment` in that module.

### Numba caching

The [Performance project](https://github.com/orgs/sot/projects/7/views/1) improvements rely in part on numba, and the JIT compilation time is substantial, as much as 5-10 seconds. In many circumstances this negates the performance improvement, and overall is just annoying.

Numba provides caching of the compiled code, but by default this lives in the __pycache__ directory of the installed code. That seems undesirable for our use case, so this PR globally overrides `NUMBA_CACHE_DIR` to place the cache in the user's `~/.ska3/cache/numba` directory. **This full directory is created by numba if it doesn't exist.**

### Documentation

Running sphinx generates some warnings. A few of them were straightforward to fix as long as I was in the code. After doing this I built the docs and confirmed the expected (better) output.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None, except that `NUMBA_CACHE_DIR` is set as an environment variable once any Ska3 package is imported.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

I also confirmed the cache directory looked reasonable on Windows (Jean)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I installed this into a ska3-dev environment and then did:
```
from Chandra.Maneuvers import attitudes
atts = attitudes([0, 0, 0], [10, 20, 30])
```
The first time this took about 10 seconds to run. The second time (after quitting and restarting IPython) there was a much shorter delay, indicating the numba cache files had been created as expected. Then:
```
cd ~/.ska3
find .
```
.
./cache
./cache/numba
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun._nominal_roll-268.py38.nbi
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun.position_at_jd-96.py38.1.nbc
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun.sph_dist-174.py38.nbi
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun._nominal_roll-268.py38.1.nbc
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun.sph_dist-174.py38.1.nbc
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun._radec2eci-227.py38.1.nbc
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun.position_at_jd-96.py38.nbi
./cache/numba/ska_sun_c7abc21ac1d69547990a52b44a4a65524c778a4b/sun._radec2eci-227.py38.nbi
./cache/numba/Quaternion_fed4fb47e6cc6b7b7bb37c510f4c78d6e5056826
./cache/numba/Quaternion_fed4fb47e6cc6b7b7bb37c510f4c78d6e5056826/Quaternion.quat_to_equatorial-50.py38.1.nbc
./cache/numba/Quaternion_fed4fb47e6cc6b7b7bb37c510f4c78d6e5056826/Quaternion.quat_to_equatorial-50.py38.nbi
./cache/numba/Quaternion_fed4fb47e6cc6b7b7bb37c510f4c78d6e5056826/Quaternion.quat_mult-88.py38.nbi
./cache/numba/Quaternion_fed4fb47e6cc6b7b7bb37c510f4c78d6e5056826/Quaternion.quat_mult-88.py38.1.nbc
./cache/numba/Maneuver_8a5f0f2554bd90e6c35e9402daca4e9ed00697ea
./cache/numba/Maneuver_8a5f0f2554bd90e6c35e9402daca4e9ed00697ea/maneuver.make_phi_dphi-166.py38.1.nbc
./cache/numba/Maneuver_8a5f0f2554bd90e6c35e9402daca4e9ed00697ea/maneuver.make_phi_dphi-166.py38.nbi
```

