### PR TITLE
Add `paths` module for global path definitions

### DIFF
--- a/ska_helpers/paths.py
+++ b/ska_helpers/paths.py
@@ -1,0 +1,94 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import os
+from pathlib import Path
+
+# Name of environment variable to override default root for chandra_models repository
+# directory. The name is misleading but this is used by the Matlab tools to override the
+# default root for chandra_models.
+CHANDRA_MODELS_ROOT_ENV_VAR = "THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW"
+
+
+def chandra_models_repo_path() -> Path:
+    """Get path to chandra_models git repository.
+
+    This returns a Path object pointing at the ``chandra_models`` repository in the
+    Ska data directory. By default is this returns ``$SKA/data/chandra_models``.
+
+    If the environment variable ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW`` is set then
+    the path will be ``$THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW``.
+
+    :returns: Path object
+        Path to ``chandra_models`` repository
+    """
+    default_root = Path(
+        os.environ["SKA"],
+        "data",
+        "chandra_models",
+    )
+    root = os.environ.get(CHANDRA_MODELS_ROOT_ENV_VAR, default_root)
+
+    return Path(root)
+
+
+def chandra_models_path(repo_path=None) -> Path:
+    """Get path to chandra_models data files directory.
+
+    This returns a Path object pointing at the ``chandra_models/`` directory in the
+    ``chandra_models`` repository.
+
+    :param repo_path: optional
+        Path to chandra_models repository (default described above)
+    :returns: Path object
+        Path to ``chandra_models`` data files directory.
+    """
+    if repo_path is None:
+        repo_path = chandra_models_repo_path()
+    else:
+        repo_path = Path(repo_path)
+
+    path = repo_path / "chandra_models"
+
+    return path
+
+
+def aca_drift_model_path(repo_path=None) -> Path:
+    """
+    Get path to chandra_models aca_drift_model.json file.
+
+    :param repo_path: optional
+        Path to chandra_models repository
+    :returns: Path object
+        Path to chandra_models ``aca_drift_model.json`` file.
+    """
+    path = chandra_models_path(repo_path) / "aca_drift" / "aca_drift_model.json"
+
+    return path
+
+
+def aca_acq_prob_models_path(repo_path=None) -> Path:
+    """
+    Get path to chandra_models aca_acq_prob models directory.
+
+    :param repo_path: optional
+        Path to chandra_models repository
+    :returns: Path object
+        Path to chandra_models ``aca_acq_prob`` models directory.
+    """
+    path = chandra_models_path(repo_path) / "aca_acq_prob"
+
+    return path
+
+
+def xija_models_path(repo_path=None) -> Path:
+    """
+    Get path to chandra_models xija models directory.
+
+    :param repo_path: optional
+        Path to chandra_models repository
+    :returns: Path object
+        Path to chandra_models ``xija`` models directory.
+    """
+    path = chandra_models_path(repo_path) / "xija"
+
+    return path

--- a/ska_helpers/tests/test_paths.py
+++ b/ska_helpers/tests/test_paths.py
@@ -1,0 +1,41 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from pathlib import Path
+import os
+
+import pytest
+from ska_helpers import paths
+
+
+@pytest.mark.parametrize("repo_source", ["default", "env", "kwargs"])
+def test_chandra_models_paths(repo_source, monkeypatch):
+    if repo_source == "env":
+        root = Path("/", "foo", "chandra_models")
+        monkeypatch.setenv(paths.CHANDRA_MODELS_ROOT_ENV_VAR, str(root))
+        kwargs = {}
+    elif repo_source == "default":
+        root = Path(os.environ["SKA"]) / "data" / "chandra_models"
+        kwargs = {}
+    elif repo_source == "kwargs":
+        root = Path("/", "bar", "chandra_models")
+        kwargs = {"repo_path": str(root)}
+    else:
+        raise ValueError(f"Unexpected repo_source={repo_source}")
+
+    if repo_source == "kwargs":
+        repo = Path(root)
+    else:
+        repo = paths.chandra_models_repo_path()
+    assert repo == root
+
+    mdls = paths.chandra_models_path(**kwargs)
+    assert mdls == root / "chandra_models"
+
+    drift = paths.aca_drift_model_path(**kwargs)
+    assert drift == mdls / "aca_drift" / "aca_drift_model.json"
+
+    acq_prob = paths.aca_acq_prob_models_path(**kwargs)
+    assert acq_prob == mdls / "aca_acq_prob"
+
+    xija = paths.xija_models_path(**kwargs)
+    assert xija == mdls / "xija"


### PR DESCRIPTION
## Description

This introduces a new home for global Ska paths. The current use case is defining paths related to `chandra_models`, which gets used in `chandra_aca.star_probs` and `xija.get_model_spec`.

### Related PR's:

- https://github.com/sot/chandra_aca/pull/140
- https://github.com/sot/xija/pull/133
- https://github.com/sot/ska_testr/pull/64

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
