### PR TITLE
Add propagate=False opt to basic_logger()

### DIFF
--- a/ska_helpers/logging.py
+++ b/ska_helpers/logging.py
@@ -3,7 +3,9 @@
 __all__ = ["basic_logger"]
 
 
-def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs):
+def basic_logger(
+    name, format="%(asctime)s %(funcName)s: %(message)s", propagate=False, **kwargs
+):
     """Create logger ``name`` using logging.basicConfig.
 
     This is a thin wrapper around logging.basicConfig, except:
@@ -16,13 +18,19 @@ def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs)
       It will probably work but it is not guaranteed.
 
     This function does nothing if the ``name`` logger already has handlers
-    configured, unless the keyword argument *force* is set to ``True``.
+    configured, unless the keyword argument ``force`` is set to ``True``.
     It is a convenience method intended to do one-shot creation of a logger.
 
     The default behaviour is to create a StreamHandler which writes to
     ``sys.stderr``, set a formatter using the format string ``"%(asctime)s
     %(funcName)s: %(message)s"``, and add the handler to the ``name`` logger
     with a level of WARNING.
+
+    By default the created logger will not propagate to parent loggers. This
+    is to prevent unexpected logging from other packages that set up a root
+    logger. To propagate to parent loggers, set ``propagate=True``. See
+    https://docs.python.org/3/howto/logging.html#logging-flow, in particular
+    how the log level of parent loggers is ignored in message handling.
 
     Example::
 
@@ -85,6 +93,8 @@ def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs)
         logger name
     format : str
         format string for handler
+    propagate: bool
+        propagate to parent loggers (default=False)
     **kwargs : dict
         other keyword arguments for logging.basicConfig
 
@@ -110,5 +120,7 @@ def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs)
         logging.basicConfig(**kwargs)
     finally:
         logging.root = root
+
+    logger.propagate = propagate
 
     return logger

--- a/ska_helpers/logging.py
+++ b/ska_helpers/logging.py
@@ -109,7 +109,7 @@ def basic_logger(
     logger = logging.getLogger(name)
 
     if not kwargs.get("force", False) and (
-        logger.hasHandlers() or logger.level != logging.NOTSET
+        logger.handlers or logger.level != logging.NOTSET
     ):
         return logger
 


### PR DESCRIPTION
## Description

This adds a keyword argument `propagate=False` to the `logging.basic_logger()` signature. The returned `logger` has `propagate` set to the input value.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This changes the behavior of `basic_logger`, but in a way that is likely expected anyway. I checked all current uses of `basic_logger` in Ska and none of them would expect to propagate messages to a root or parent logger.

@javierggt - you should double-check `astromon` though.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
From this branch in the git repo:
```
$ ipython
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import annie
WARNING: AstropyDeprecationWarning: http://bugs.python.org/issue12166 is resolved. See docstring for alternatives. [chandra_aca.aca_image]
AstropyDeprecationWarning: http://bugs.python.org/issue12166 is resolved. See docstring for alternatives.

In [2]: import cheta
```
Previously the `annie` and `cheta` imports generated debug information from `get_version()` calls due to `annie` creating a root logger on import. This was because `get_version()` uses logging to catch debug information in an `io.String()` object, and all of those messages then get passed up to the parent where they get emitted regardless of the parent log level. (The annie root logger is at CRITICAL, but only the level of the handlers (NOTSET) is evaluated).
