### PR TITLE
Add support for reading chandra_models data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,12 @@ Ska Package Helpers
 .. automodule:: ska_helpers
    :members:
 
+Chandra Models Data
+-------------------
+
+.. automodule:: ska_helpers.chandra_models
+   :members:
+
 Logging
 -------
 
@@ -37,8 +43,8 @@ Utilities
    :members:
 
 
-Get Version
------------
+Version Info
+------------
 
 .. automodule:: ska_helpers.version
    :members:

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -1,0 +1,229 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Get data from chandra_models repository.
+"""
+import contextlib
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+import git
+import requests
+
+from ska_helpers.paths import chandra_models_repo_path
+
+__all__ = [
+    "get_data",
+    "get_repo_version",
+    "get_github_version",
+]
+
+CHANDRA_MODELS_LATEST_URL = (
+    "https://api.github.com/repos/sot/chandra_models/releases/latest"
+)
+
+
+def get_data(
+    file_path: str | Path,
+    version: Optional[str] = None,
+    repo_path: Optional[str | Path] = None,
+    require_latest_version: bool = False,
+    timeout: int | float = 5,
+    read_func: Optional[Callable] = None,
+    read_func_kwargs: Optional[dict] = None,
+) -> tuple:
+    """
+    Get data from chandra_models repository.
+
+    Examples
+    --------
+    First we read the model specification for the ACA model. The ``get_data()`` function
+    returns the text of the model spec so we need to use ``json.loads()`` to convert it
+    to a dict.
+
+        >>> import json
+        >>> from astropy.io import fits
+        >>> from ska_helpers import chandra_models
+
+        >>> txt = chandra_models.get_data("chandra_models/xija/aca/aca_spec.json")
+        >>> model_spec = json.loads(txt)
+        >>> model_spec["name"]
+        'aacccdpt'
+
+    Next we read the acquisition probability model image. Since the image is a gzipped
+    FITS file we need to use a helper function to read it.
+
+        >>> def read_fits_image(file_path):
+        ...     with fits.open(file_path) as hdus:
+        ...         out = hdus[1].data
+        ...     return out
+        ...
+        >>> acq_model_image = chandra_models.get_data(
+        ...     "chandra_models/aca_acq_prob/grid-floor-2018-11.fits.gz",
+        ...     read_func=read_fits_image
+        ... )
+        >>> acq_model_image.shape
+        ...
+        (141, 31, 7)
+
+    Now let's get the version of the chandra_models repository::
+
+        >>> chandra_models.get_repo_version()
+        '3.47'
+
+
+    Finally get version 3.30 of the ACA model spec from GitHub. The use of a lambda
+    function to read the JSON file is compact but not recommended for production code.
+
+        >>> model_spec_3_30 = chandra_models.get_data(
+        ...     "chandra_models/xija/aca/aca_spec.json",
+        ...     version="3.30",
+        ...     repo_path="https://github.com/sot/chandra_models.git",
+        ...     read_func=lambda fn: json.load(open(fn, "rb")),
+        ... )
+        >>> model_spec_3_30 == model_spec
+        False
+
+    Parameters
+    ----------
+    file_path : str, Path
+        Name of model
+    version : str
+        Tag, branch or commit of chandra_models to use (default=latest tag from repo)
+    repo_path : str, Path
+        Path to directory or URL containing chandra_models repository (default is
+        $SKA/data/chandra_models or the THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW
+        environment variable if set)
+    require_latest_version : bool
+        Require that ``version`` matches the latest release on GitHub
+    timeout : int, float
+        Timeout (sec) for querying GitHub for the expected chandra_models version.
+        Default = 5 sec.
+    read_func : callable
+        Optional function to read the data file. This function must take the file path
+        as its first argument. If not provided then read the file as a text file.
+    read_func_kwargs : dict
+        Optional dict of kwargs to pass to ``read_func``.
+
+    Returns
+    -------
+    tuple of dict, str
+        Xija model specification dict, chandra_models version
+    """
+    if repo_path is None:
+        repo_path = chandra_models_repo_path()
+
+    # NOTE code in xija.get_model_spec.get_repo_version() that does something Windows
+    # specific which I don't completely understand.
+    #
+    # with temp_directory() as repo_path_local:
+    #     if platform.system() == 'Windows':
+    #         repo = git.Repo.clone_from(repo_path, repo_path_local)
+    #     else:
+    #         repo = git.Repo(repo_path)
+
+    # Potentially work in a clone of the repo in a temporary directory, but only if
+    # necessary.
+    with contextlib.ExitStack() as stack:
+        if str(repo_path).startswith("https://github.com") or version is not None:
+            # For a remote GitHub repo or non-default version, clone to a temp dir
+            repo_path_local = stack.enter_context(tempfile.TemporaryDirectory())
+            repo = git.Repo.clone_from(repo_path, repo_path_local)
+            if version is not None:
+                repo.git.checkout(version)
+        else:
+            # For a local repo at the default version use the existing directory
+            repo = git.Repo(repo_path)
+            repo_path_local = repo_path
+
+        repo_file_path = Path(repo_path_local) / file_path
+        if not repo_file_path.exists():
+            raise FileNotFoundError(f"chandra_models {file_path=} does not exist")
+
+        if version is None:
+            # This also ensures that the repo is not dirty.
+            version = get_repo_version(repo=repo)
+
+        if require_latest_version:
+            assert_latest_version(version, timeout)
+
+        if read_func is None:
+            data = repo_file_path.read_text()
+        else:
+            if read_func_kwargs is None:
+                read_func_kwargs = {}
+            data = read_func(repo_file_path, **read_func_kwargs)
+
+    return data
+
+
+def assert_latest_version(version, timeout):
+    gh_version = get_github_version(timeout=timeout)
+    if gh_version is None:
+        warnings.warn(
+            "Could not verify GitHub chandra_models release tag "
+            f"due to timeout ({timeout} sec)"
+        )
+    elif version != gh_version:
+        raise ValueError(
+            f"version mismatch: local repo {version} vs " f"github {gh_version}"
+        )
+
+
+def get_repo_version(
+    repo_path: Optional[Path] = None, repo: Optional[git.Repo] = None
+) -> str:
+    """Return version (most recent tag) of models repository.
+
+    Returns
+    -------
+    str
+        Version (most recent tag) of models repository
+    """
+    if repo is None:
+        if repo_path is None:
+            repo_path = chandra_models_repo_path()
+        repo = git.Repo(repo_path)
+
+    if repo.is_dirty():
+        raise ValueError("repo is dirty")
+
+    tags = sorted(repo.tags, key=lambda tag: tag.commit.committed_datetime)
+    tag_repo = tags[-1]
+    if tag_repo.commit != repo.head.commit:
+        raise ValueError(f"repo tip is not at tag {tag_repo}")
+
+    return tag_repo.name
+
+
+def get_github_version(
+    url: str = CHANDRA_MODELS_LATEST_URL, timeout: Union[int, float] = 5
+) -> Optional[bool]:
+    """Get latest chandra_models GitHub repo release tag (version).
+
+    This queries GitHub for the latest release of chandra_models.
+
+    Parameters
+    ----------
+    url : str
+        URL for latest chandra_models release on GitHub API
+    timeout : int, float
+        Request timeout (sec, default=5)
+
+    Returns
+    -------
+    str, None
+        Tag name (str) of latest chandra_models release on GitHub.
+        None if the request timed out, indicating indeterminate answer.
+    """
+    try:
+        req = requests.get(url, timeout=timeout)
+    except (requests.ConnectTimeout, requests.ReadTimeout):
+        return None
+
+    if req.status_code != requests.codes.ok:
+        req.raise_for_status()
+
+    page_json = req.json()
+    return page_json["tag_name"]

--- a/ska_helpers/logging.py
+++ b/ska_helpers/logging.py
@@ -40,28 +40,37 @@ def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs)
 
     filename  Specifies that a FileHandler be created, using the specified
               filename, rather than a StreamHandler.
+
     filemode  Specifies the mode to open the file, if filename is specified
               (if filemode is unspecified, it defaults to 'a').
+
     format    Use the specified format string for the handler.
+
     datefmt   Use the specified date/time format.
+
     style     If a format string is specified, use this to specify the
               type of format string (possible values '%', '{', '$', for
               %-formatting, :meth:`str.format` and :class:`string.Template`
               - defaults to '%').
+
     level     Set the ``name`` logger level to the specified level. This can be
               a number (10, 20, ...) or a string ('NOTSET', 'DEBUG', 'INFO',
               'WARNING', 'ERROR', 'CRITICAL') or ``logging.DEBUG``, etc.
+
     stream    Use the specified stream to initialize the StreamHandler. Note
               that this argument is incompatible with 'filename' - if both
               are present, 'stream' is ignored.
+
     handlers  If specified, this should be an iterable of already created
               handlers, which will be added to the ``name`` handler. Any handler
               in the list which does not have a formatter assigned will be
               assigned the formatter created in this function.
+
     force     If this keyword  is specified as true, any existing handlers
               attached to the ``name`` logger are removed and closed, before
               carrying out the configuration as specified by the other
               arguments.
+
     Note that you could specify a stream created using open(filename, mode)
     rather than passing the filename and mode in. However, it should be
     remembered that StreamHandler does not close its stream (since it may be
@@ -70,10 +79,18 @@ def basic_logger(name, format="%(asctime)s %(funcName)s: %(message)s", **kwargs)
 
     Note this function is probably not thread-safe.
 
-    :param name: str, logger name
-    :param format: str, format string for handler
-    :param **kwargs: other keyword arguments for logging.basicConfig
-    :returns: Logger object
+    Parameters
+    ----------
+    name : str
+        logger name
+    format : str
+        format string for handler
+    **kwargs : dict
+        other keyword arguments for logging.basicConfig
+
+    Returns
+    -------
+    logger : Logger object
     """
     import logging
 

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -12,7 +12,9 @@ class RetryError(Exception):
     """
     Keep track of the stack of exceptions when trying multiple times.
 
-    :param exceptions: list of dict, each with keys 'type', 'value', 'trace'.
+    Parameters
+    ----------
+    failures : list of dict, each with keys 'type', 'value', 'trace'.
     """
 
     def __init__(self, failures):

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -1,0 +1,128 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import json
+import re
+
+import git
+import pytest
+import requests
+from astropy.io import fits
+
+from ska_helpers import chandra_models
+
+try:
+    # Fast request to see if GitHub is available
+    req = requests.get(
+        "https://raw.githubusercontent.com/sot/chandra_models/master/README.md",
+        timeout=5,
+    )
+    HAS_GITHUB = req.status_code == 200
+except Exception:
+    HAS_GITHUB = False
+
+
+ACA_SPEC_PATH = "chandra_models/xija/aca/aca_spec.json"
+
+
+def read_xija_spec(fn):
+    with open(fn) as fh:
+        spec = json.load(fh)
+    return spec
+
+
+def test_get_data_aca_3_30():
+    # Version 3.30
+    spec_txt = chandra_models.get_data(ACA_SPEC_PATH, version="3.30")
+    spec = json.loads(spec_txt)
+    assert spec["name"] == "aacccdpt"
+    assert "comps" in spec
+    assert spec["datestop"] == "2018:305:11:52:30.816"
+
+    spec2 = chandra_models.get_data(
+        ACA_SPEC_PATH, version="3.30", read_func=read_xija_spec
+    )
+    assert spec == spec2
+
+
+def test_get_data_extra_kwargs():
+    def read_fits_image(file_path, hdu_num=0):
+        with fits.open(file_path) as hdus:
+            out = hdus[hdu_num].data
+        return out
+
+    acq_model_image = chandra_models.get_data(
+        "chandra_models/aca_acq_prob/grid-floor-2018-11.fits.gz",
+        read_func=read_fits_image,
+        read_func_kwargs={"hdu_num": 1},
+    )
+    assert acq_model_image.shape == (141, 31, 7)
+
+
+def test_get_data_aca_latest():
+    # Latest version
+    spec = chandra_models.get_data(
+        ACA_SPEC_PATH, require_latest_version=HAS_GITHUB, read_func=read_xija_spec
+    )
+    assert spec["name"] == "aacccdpt"
+    # version 3.30 value, changed in 3.31.1/3.32
+    assert spec["datestop"] != "2018:305:11:52:30.816"
+    assert "comps" in spec
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
+def test_get_data_require_latest_version_fail():
+    with pytest.raises(ValueError, match="version mismatch"):
+        chandra_models.get_data(
+            ACA_SPEC_PATH, version="3.30", require_latest_version=True
+        )
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
+def test_get_data_aca_from_github():
+    # Latest version
+    repo_path = "https://github.com/sot/chandra_models.git"
+    spec = chandra_models.get_data(
+        ACA_SPEC_PATH, repo_path=repo_path, version="3.30", read_func=read_xija_spec
+    )
+    assert spec["name"] == "aacccdpt"
+    assert spec["datestop"] == "2018:305:11:52:30.816"
+    assert "comps" in spec
+
+
+def test_get_model_file_fail():
+    with pytest.raises(
+        FileNotFoundError, match=r"chandra_models file_path='xxxyyyzzz' does not exist"
+    ):
+        chandra_models.get_data("xxxyyyzzz")
+
+    with pytest.raises(git.exc.NoSuchPathError):
+        chandra_models.get_data(ACA_SPEC_PATH, repo_path="__NOT_A_DIRECTORY__")
+
+
+def test_get_repo_version():
+    version = chandra_models.get_repo_version()
+    assert isinstance(version, str)
+    assert re.match(r"^[0-9.]+$", version)
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
+def test_check_github_version():
+    version = chandra_models.get_repo_version()
+    status = chandra_models.get_github_version() == version
+    assert status is True
+
+    status = chandra_models.get_github_version() == "asdf"
+    assert status is False
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
+def test_check_github_timeout():
+    # Force timeout
+    status = chandra_models.get_github_version(timeout=0.00001)
+    assert status is None
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
+def test_check_github_bad_url():
+    with pytest.raises(requests.ConnectionError):
+        chandra_models.get_github_version(url="https://______bad_url______")


### PR DESCRIPTION
## Description

This is in support of https://github.com/sot/chandra_models/issues/104 and the general effort to move more operations data or model files into `chandra_models`.

It is based heavily off of similar code in `xija.get_xija_model`.

While building the sphinx docs I saw a bunch of errors in ska3-prime and so I just fixed them here.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a new module.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (New unit tests)
- [ ] TO DO: Run unit testing run on Windows.

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
None