### PR TITLE
Add support for two new environment variables for `chandra_models` defaults

### DIFF
--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -201,6 +201,11 @@ def get_data(
                 "version": version,
                 "commit": repo.head.commit.hexsha,
                 "data_file_path": str(repo_file_path),
+                "repo_path": str(repo_path),
+                "CHANDRA_MODELS_DEFAULT_VERSION": os.environ.get(
+                    "CHANDRA_MODELS_DEFAULT_VERSION"
+                ),
+                "CHANDRA_MODELS_REPO_DIR": os.environ.get("CHANDRA_MODELS_REPO_DIR"),
                 "md5": md5,
             }
         )

--- a/ska_helpers/paths.py
+++ b/ska_helpers/paths.py
@@ -3,10 +3,13 @@
 import os
 from pathlib import Path
 
-# Name of environment variable to override default root for chandra_models repository
-# directory. The name is misleading but this is used by the Matlab tools to override the
-# default root for chandra_models.
-CHANDRA_MODELS_ROOT_ENV_VAR = "THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW"
+# Name of environment variables that can be set to override default root for
+# chandra_models repository directory. The second name is misleading but this is used by
+# the Matlab tools to override the default root for chandra_models.
+CHANDRA_MODELS_ROOT_ENV_VARS = [
+    "CHANDRA_MODELS_REPO_DIR",
+    "THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW",
+]
 
 
 def chandra_models_repo_path() -> Path:
@@ -15,20 +18,25 @@ def chandra_models_repo_path() -> Path:
     This returns a Path object pointing at the ``chandra_models`` repository in the
     Ska data directory. By default is this returns ``$SKA/data/chandra_models``.
 
-    If the environment variable ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW`` is set then
-    the path will be ``$THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW``.
+    The default root can be overridden by setting either of these environment variables,
+    which are checked in the order listed:
+
+    - ``CHANDRA_MODELS_REPO_DIR``
+    - ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW``
 
     :returns: Path object
         Path to ``chandra_models`` repository
     """
+    for env_var in CHANDRA_MODELS_ROOT_ENV_VARS:
+        if env_var in os.environ:
+            return Path(os.environ[env_var])
+
     default_root = Path(
         os.environ["SKA"],
         "data",
         "chandra_models",
     )
-    root = os.environ.get(CHANDRA_MODELS_ROOT_ENV_VAR, default_root)
-
-    return Path(root)
+    return default_root
 
 
 def chandra_models_path(repo_path=None) -> Path:

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -27,30 +27,51 @@ ACA_SPEC_PATH = "chandra_models/xija/aca/aca_spec.json"
 def read_xija_spec(fn):
     with open(fn) as fh:
         spec = json.load(fh)
-    return spec
+    return spec, fn
 
 
 def test_get_data_aca_3_30():
     # Version 3.30
-    spec_txt = chandra_models.get_data(ACA_SPEC_PATH, version="3.30")
+    spec_txt, info = chandra_models.get_data(ACA_SPEC_PATH, version="3.30")
     spec = json.loads(spec_txt)
     assert spec["name"] == "aacccdpt"
     assert "comps" in spec
     assert spec["datestop"] == "2018:305:11:52:30.816"
 
-    spec2 = chandra_models.get_data(
+    spec2, info2 = chandra_models.get_data(
         ACA_SPEC_PATH, version="3.30", read_func=read_xija_spec
     )
     assert spec == spec2
+
+    for dct in info, info2:
+        del dct["data_file_path"]
+        del dct["call_args"]["read_func"]
+        del dct["call_args"]["read_func_kwargs"]
+
+    assert info == info2
+
+    exp = {
+        "call_args": {
+            "file_path": "chandra_models/xija/aca/aca_spec.json",
+            "version": "3.30",
+            "repo_path": "None",
+            "require_latest_version": False,
+            "timeout": 5,
+        },
+        "version": "3.30",
+        "commit": "94d2fa56bac1637cbfe63bcb1bc9294954379c11",
+        "md5": "0e72b6402b8ed1fbaf81d5e79232461b",
+    }
+    assert info == exp
 
 
 def test_get_data_extra_kwargs():
     def read_fits_image(file_path, hdu_num=0):
         with fits.open(file_path) as hdus:
             out = hdus[hdu_num].data
-        return out
+        return out, file_path
 
-    acq_model_image = chandra_models.get_data(
+    acq_model_image, info = chandra_models.get_data(
         "chandra_models/aca_acq_prob/grid-floor-2018-11.fits.gz",
         read_func=read_fits_image,
         read_func_kwargs={"hdu_num": 1},
@@ -60,7 +81,7 @@ def test_get_data_extra_kwargs():
 
 def test_get_data_aca_latest():
     # Latest version
-    spec = chandra_models.get_data(
+    spec, info = chandra_models.get_data(
         ACA_SPEC_PATH, require_latest_version=HAS_GITHUB, read_func=read_xija_spec
     )
     assert spec["name"] == "aacccdpt"
@@ -81,7 +102,7 @@ def test_get_data_require_latest_version_fail():
 def test_get_data_aca_from_github():
     # Latest version
     repo_path = "https://github.com/sot/chandra_models.git"
-    spec = chandra_models.get_data(
+    spec, info = chandra_models.get_data(
         ACA_SPEC_PATH, repo_path=repo_path, version="3.30", read_func=read_xija_spec
     )
     assert spec["name"] == "aacccdpt"

--- a/ska_helpers/tests/test_paths.py
+++ b/ska_helpers/tests/test_paths.py
@@ -1,17 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from pathlib import Path
 import os
+from pathlib import Path
 
 import pytest
+
 from ska_helpers import paths
 
 
 @pytest.mark.parametrize("repo_source", ["default", "env", "kwargs"])
-def test_chandra_models_paths(repo_source, monkeypatch):
+@pytest.mark.parametrize("chandra_models_repo_dir", paths.CHANDRA_MODELS_ROOT_ENV_VARS)
+def test_chandra_models_paths(repo_source, chandra_models_repo_dir, monkeypatch):
     if repo_source == "env":
         root = Path("/", "foo", "chandra_models")
-        monkeypatch.setenv(paths.CHANDRA_MODELS_ROOT_ENV_VAR, str(root))
+        monkeypatch.setenv(chandra_models_repo_dir, str(root))
         kwargs = {}
     elif repo_source == "default":
         root = Path(os.environ["SKA"]) / "data" / "chandra_models"


### PR DESCRIPTION
## Description

This adds two new environment variables that impact the behavior:

- ``CHANDRA_MODELS_REPO_DIR`` as an alias for ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW``:
      override the default root for the chandra_models repository. The name defined by FOT Matlab tools is impossible
      to remember. :smile:
- ``CHANDRA_MODELS_DEFAULT_VERSION``: override the default repo version. 

Adding, ``CHANDRA_MODELS_DEFAULT_VERSION`` environment variable might be controversial but this greatly facilitates two important use cases:
- Setting version to a fixed version in unit tests (e.g. with ``monkeypatch``)
- Set to a developement branch to test a model file update with applications like yoshi where
   specifying a version would require a long chain of API updates.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

@jeanconn extracted the FOT Matlab tools archive of `chandra_models`. This looks like below, where each directory is a shallow git repo with just the latest commit:
```
ska3-dev) ➜  chandra_aca git:(model-globs) ls /Users/aldcroft/Downloads/Thermal_Models
Archive/               chandra_models-3.43/   chandra_models-3.44/   chandra_models-3.46/   chandra_models-3.48/
chandra_models-3.41.1/ chandra_models-3.43.1/ chandra_models-3.45/   chandra_models-3.47/
```

Then I did the following in a dev ska with this repo installed:

```
In [11]: os.environ[
    ...:     "CHANDRA_MODELS_REPO_DIR"
    ...: ] = "/Users/aldcroft/Downloads/Thermal_Models/chandra_models-3.47"

In [12]: data, info = chandra_models.get_data("chandra_models/xija/aca/aca_spec.json")

In [13]: import json

In [14]: spec = json.loads(data)

In [15]: spec["name"]
Out[15]: 'aacccdpt'

In [16]: info
Out[16]: 
{'call_args': {'file_path': 'chandra_models/xija/aca/aca_spec.json',
  'version': None,
  'repo_path': 'None',
  'require_latest_version': False,
  'timeout': 5,
  'read_func': 'None',
  'read_func_kwargs': None},
 'version': '3.47',
 'commit': '5307bf8ad3a8588de3417b44f8eddf2a5a26a9e0',
 'data_file_path': '/Users/aldcroft/Downloads/Thermal_Models/chandra_models-3.47/chandra_models/xija/aca/aca_spec.json',
 'repo_path': '/Users/aldcroft/Downloads/Thermal_Models/chandra_models-3.47',
 'CHANDRA_MODELS_DEFAULT_VERSION': None,
 'CHANDRA_MODELS_REPO_DIR': '/Users/aldcroft/Downloads/Thermal_Models/chandra_models-3.47',
 'md5': '71cda7e5c2c5f72e5007f5d79014bd14'}

In [17]: del os.environ["CHANDRA_MODELS_REPO_DIR"]

In [18]: data, info = chandra_models.get_data("chandra_models/xija/aca/aca_spec.json")

In [19]: info
Out[19]: 
{'call_args': {'file_path': 'chandra_models/xija/aca/aca_spec.json',
  'version': None,
  'repo_path': 'None',
  'require_latest_version': False,
  'timeout': 5,
  'read_func': 'None',
  'read_func_kwargs': None},
 'version': '3.48',
 'commit': '68a58099a9b51bef52ef14fbd0f1971f950e6ba3',
 'data_file_path': '/Users/aldcroft/ska/data/chandra_models/chandra_models/xija/aca/aca_spec.json',
 'repo_path': '/Users/aldcroft/ska/data/chandra_models',
 'CHANDRA_MODELS_DEFAULT_VERSION': None,
 'CHANDRA_MODELS_REPO_DIR': None,
 'md5': '71cda7e5c2c5f72e5007f5d79014bd14'}
```

