### PR TITLE
Fixes to get chandra_models and paths working on Windows

### DIFF
--- a/ska_helpers/tests/test_paths.py
+++ b/ska_helpers/tests/test_paths.py
@@ -16,6 +16,9 @@ def test_chandra_models_paths(repo_source, chandra_models_repo_dir, monkeypatch)
         monkeypatch.setenv(chandra_models_repo_dir, str(root))
         kwargs = {}
     elif repo_source == "default":
+        # Make sure no path-changing env vars are set
+        for env_var in paths.CHANDRA_MODELS_ROOT_ENV_VARS:
+            monkeypatch.delenv(env_var, raising=False)
         root = Path(os.environ["SKA"]) / "data" / "chandra_models"
         kwargs = {}
     elif repo_source == "kwargs":


### PR DESCRIPTION
## Description

With these changes the package is passing unit tests on Windows, assuming that the `chandra_models` repo that it sees is not "dirty". That currently happens if the repo is cross mounted in Parallels from a Mac. For my testing I defined the `CHANDRA_MODELS_REPO_DIR` environment to point to a clean version of the repo. This in turn led to another fix in the tests.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] Mac : TODO
- [ ] Linux : TODO
- [x] Windows

Independent check of unit tests by Javier
- [x] Mac
- [x] Linux
- [x] Windows

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
