### PR TITLE
Add git_helpers.py w/ function for safe directory handling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,11 @@ Environment
 .. automodule:: ska_helpers.environment
    :members:
 
+Git helpers
+-----------
+
+.. automodule:: ska_helpers.git_helpers
+   :members:
 
 Logging
 -------

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -2,16 +2,21 @@
 """
 Helper functions for using git.
 """
+import functools
 import re
 import subprocess
-from pathlib import Path
 import sys
 import warnings
+from pathlib import Path
 
 from ska_file import chdir
 
 
-def make_git_repo_safe(path: str | Path) -> str:
+__all__ = ["make_git_repo_safe"]
+
+
+@functools.lru_cache()
+def make_git_repo_safe(path: str | Path) -> None:
     """Ensure git repo at ``path`` is a safe git repository.
 
     A "safe" repo is one which is owned by the user calling this function. See:
@@ -60,10 +65,10 @@ def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
 
     # Error message from the failed git command, which looks like this:
     # $ git status
-    # fatal: detected dubious ownership in repository at '//Mac/Home/ska/data/chandra_models'
+    # fatal: detected dubious ownership in repository at '//Mac/Home/ska/data/chandra_models'  # noqa: E501
     # To add an exception for this directory, call:
     #
-    #    git config --global --add safe.directory '%(prefix)///Mac/Home/ska/data/chandra_models'
+    #    git config --global --add safe.directory '%(prefix)///Mac/Home/ska/data/chandra_models'  # noqa: E501
 
     err = proc.stderr.decode().strip()
 

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -60,7 +60,7 @@ def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
     # %(prefix)///Mac/ska/data/chandra_models. Using the original ``path`` does
     # not work.
     git_safe_config_RE = (
-        r"(git) (config) (--global) (--add) (safe\.directory) '([^\']+)'"
+        r"(git) (config) (--global) (--add) (safe\.directory) (\S+)"
     )
 
     # Error message from the failed git command, which looks like this:
@@ -73,7 +73,8 @@ def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
     err = proc.stderr.decode().strip()
 
     if match := re.search(git_safe_config_RE, err, re.MULTILINE):
-        cmds = match.groups()
+        cmds = list(match.groups())
+        cmds[-1] = cmds[-1].strip("'")
         warnings.warn(
             "Updating git config to allow read-only git operations on "
             f"trusted repository {path}. Contact Ska team for questions.",

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -1,0 +1,80 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Helper functions for using git.
+"""
+import re
+import subprocess
+from pathlib import Path
+import sys
+import warnings
+
+from ska_file import chdir
+
+
+def make_git_repo_safe(path: str | Path) -> str:
+    """Ensure git repo at ``path`` is a safe git repository.
+
+    A "safe" repo is one which is owned by the user calling this function. See:
+    https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765
+
+    If an unsafe repo is detected then this command issues a warning to that
+    effect and then updates the user's git config to add this repo as a safe
+    directory.
+
+    This function should only be called for known safe git repos such as
+    ``$SKA/data/chandra_models``.
+
+    :param path: str, Path
+        Path to top level of a git repository
+    """  # noqa
+    path = Path(path)
+    if not (path / ".git").exists():
+        raise FileNotFoundError(f"'{path}' is not the top level of a git repo")
+
+    with chdir(path):
+        # Run a lightweight command which will fail for an unsafe repo
+        proc = subprocess.run(["git", "rev-parse"], capture_output=True)
+        if proc.returncode != 0:
+            _handle_rev_parse_failure(path, proc)
+            # Ensure that the repo is now safe. This will raise an exception
+            # otherwise.
+            subprocess.check_call(["git", "rev-parse"])
+
+
+def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
+    """Handle a failure of `git --rev-parse` command.
+
+    This is most likely due to repo not being safe. If that is the case (based
+    on the command error output) then issue a warning and update the user git
+    config. Otherwise print the error text and raise an exception.
+    """
+    # Regex of command that is provided by git to mark a directory as safe. The
+    # suggested directory name (last group) may be very different from the
+    # original ``path``. For example on Windows with a VM shared directory
+    # Y:\data\chandra_models, the required git config safe.directory is
+    # %(prefix)///Mac/ska/data/chandra_models. Using the original ``path`` does
+    # not work.
+    git_safe_config_RE = (
+        r"(git) (config) (--global) (--add) (safe\.directory) '([^\']+)'"
+    )
+
+    # Error message from the failed git command, which looks like this:
+    # $ git status
+    # fatal: detected dubious ownership in repository at '//Mac/Home/ska/data/chandra_models'
+    # To add an exception for this directory, call:
+    #
+    #    git config --global --add safe.directory '%(prefix)///Mac/Home/ska/data/chandra_models'
+
+    err = proc.stderr.decode().strip()
+
+    if match := re.search(git_safe_config_RE, err, re.MULTILINE):
+        cmds = match.groups()
+        warnings.warn(
+            "Updating git config to allow read-only git operations on "
+            f"trusted repository {path}. Contact Ska team for questions.",
+            stacklevel=3,
+        )
+        subprocess.check_call(cmds)
+    else:
+        print(err, file=sys.stderr)
+        proc.check_returncode()

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -59,9 +59,7 @@ def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
     # Y:\data\chandra_models, the required git config safe.directory is
     # %(prefix)///Mac/ska/data/chandra_models. Using the original ``path`` does
     # not work.
-    git_safe_config_RE = (
-        r"(git) (config) (--global) (--add) (safe\.directory) (\S+)"
-    )
+    git_safe_config_RE = r"(git) (config) (--global) (--add) (safe\.directory) (\S+)"
 
     # Error message from the failed git command, which looks like this:
     # $ git status

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -10,6 +10,9 @@ CHANDRA_MODELS = Path(os.environ["SKA"]) / "data" / "chandra_models"
 
 
 def ska_ownership_ok():
+    # Check that the OS and volume support file ownership
+    # (not the case with shared directories on a Windows VM on parallels)
+    # and that the chandra_models dir is owned by the current user
     try:
         return CHANDRA_MODELS.owner() == os.getlogin()
     except Exception:
@@ -21,13 +24,17 @@ def ska_ownership_ok():
 )
 @pytest.mark.skipif(ska_ownership_ok(), reason="Chandra models dir ownership is OK")
 def test_make_git_repo_safe(monkeypatch):
-    with (
-        tempfile.TemporaryDirectory() as tempdir,
-        pytest.warns(UserWarning, match="Updating git config"),
-    ):
+    with tempfile.TemporaryDirectory() as tempdir:
+        # temporarily set HOME to a temp dir so .gitconfig comes from there
         monkeypatch.setenv("HOME", tempdir)
         repo = git.Repo(CHANDRA_MODELS)
         with pytest.raises(git.exc.GitCommandError):
+            # This statement fails with the error
+            #     fatal: detected dubious ownership
+            # unless the repo is marked safe in .gitconfig
             repo.is_dirty()
-        git_helpers.make_git_repo_safe(CHANDRA_MODELS)
+        with pytest.warns(UserWarning, match="Updating git config"):
+            # marke the repo safe and issue warning
+            git_helpers.make_git_repo_safe(CHANDRA_MODELS)
+        # success
         repo.is_dirty()

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -1,0 +1,20 @@
+import pytest
+import tempfile
+from ska_helpers import git_helpers
+import git
+import os
+
+from testr.test_helper import on_head_network
+
+# @pytest.mark.filterwarnings("ignore:Updating git config")
+@pytest.mark.skipif(not on_head_network(), reason='bla')
+def test_make_git_repo_safe():
+    with tempfile.TemporaryDirectory() as d, pytest.warns(
+        UserWarning, match="Updating git config"
+    ):
+        os.environ["HOME"] = d
+        repo = git.Repo("/proj/sot/ska/data/chandra_models")
+        with pytest.raises(git.exc.GitCommandError):
+            repo.is_dirty()
+        git_helpers.make_git_repo_safe("/proj/sot/ska/data/chandra_models")
+        repo.is_dirty()

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -1,12 +1,13 @@
-import pytest
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import getpass
 import tempfile
-from ska_helpers import git_helpers
+
 import git
-import os
-from pathlib import Path
+import pytest
 
+from ska_helpers import git_helpers, paths
 
-CHANDRA_MODELS = Path(os.environ["SKA"]) / "data" / "chandra_models"
+CHANDRA_MODELS = paths.chandra_models_repo_path()
 
 
 def ska_ownership_ok():
@@ -14,13 +15,14 @@ def ska_ownership_ok():
     # (not the case with shared directories on a Windows VM on parallels)
     # and that the chandra_models dir is owned by the current user
     try:
-        return CHANDRA_MODELS.owner() == os.getlogin()
+        return CHANDRA_MODELS.owner() == getpass.getuser()
     except Exception:
         return False
 
 
 @pytest.mark.skipif(
-    not CHANDRA_MODELS.exists(), reason="Chandra models dir is not there"
+    not CHANDRA_MODELS.exists(),
+    reason="Chandra models dir is not there",
 )
 @pytest.mark.skipif(ska_ownership_ok(), reason="Chandra models dir ownership is OK")
 def test_make_git_repo_safe(monkeypatch):

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -6,8 +6,9 @@ import os
 
 from testr.test_helper import on_head_network
 
+
 # @pytest.mark.filterwarnings("ignore:Updating git config")
-@pytest.mark.skipif(not on_head_network(), reason='bla')
+@pytest.mark.skipif(not on_head_network(), reason="bla")
 def test_make_git_repo_safe():
     with tempfile.TemporaryDirectory() as d, pytest.warns(
         UserWarning, match="Updating git config"

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -6,6 +6,7 @@ import git
 import pytest
 
 from ska_helpers import git_helpers, paths
+from ska_helpers.utils import get_owner
 
 CHANDRA_MODELS = paths.chandra_models_repo_path()
 
@@ -15,7 +16,7 @@ def ska_ownership_ok():
     # (not the case with shared directories on a Windows VM on parallels)
     # and that the chandra_models dir is owned by the current user
     try:
-        return CHANDRA_MODELS.owner() == getpass.getuser()
+        return get_owner(CHANDRA_MODELS) == getpass.getuser()
     except Exception:
         return False
 

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -16,13 +16,16 @@ def ska_ownership_ok():
         return False
 
 
-@pytest.mark.skipif(not CHANDRA_MODELS.exists(), reason="Chandra models dir is not there")
+@pytest.mark.skipif(
+    not CHANDRA_MODELS.exists(), reason="Chandra models dir is not there"
+)
 @pytest.mark.skipif(ska_ownership_ok(), reason="Chandra models dir ownership is OK")
-def test_make_git_repo_safe():
-    with tempfile.TemporaryDirectory() as tempdir, pytest.warns(
-        UserWarning, match="Updating git config"
+def test_make_git_repo_safe(monkeypatch):
+    with (
+        tempfile.TemporaryDirectory() as tempdir,
+        pytest.warns(UserWarning, match="Updating git config"),
     ):
-        os.environ["HOME"] = tempdir
+        monkeypatch.setenv("HOME", tempdir)
         repo = git.Repo(CHANDRA_MODELS)
         with pytest.raises(git.exc.GitCommandError):
             repo.is_dirty()

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -5,6 +5,38 @@ import functools
 __all__ = ["LazyDict", "LazyVal"]
 
 
+def get_owner(path):
+    """
+    Returns the owner of a file or directory.
+
+    Parameters:
+    -----------
+    path : str or pathlib.Path
+        The path to the file or directory.
+
+    Returns:
+    --------
+    str
+        The name of the owner of the file or directory.
+    """
+
+    from testr import test_helper
+    from pathlib import Path
+
+    if test_helper.is_windows():
+        import win32security
+
+        # Suggested by copilot chat, seems to
+        security_descriptor = win32security.GetFileSecurity(
+            str(path), win32security.OWNER_SECURITY_INFORMATION
+        )
+        owner_sid = security_descriptor.GetSecurityDescriptorOwner()
+        owner_name, _, _ = win32security.LookupAccountSid(None, owner_sid)
+    else:
+        owner_name = Path(path).owner()
+    return owner_name
+
+
 def _lazy_load_wrap(unbound_method):
     @functools.wraps(unbound_method)
     def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
## Description

See https://chandramission.slack.com/archives/G01LN40AXPG/p1688129800711439 for context. See also [this blog](https://weblog.west-wind.com/posts/2023/Jan/05/Fix-that-damn-Git-Unsafe-Repository) for more info. Long story short is that git made a security update which requires setting a git config `safe.directory` in order to do any git operations on a git repo that is not owned by the user running the git command. This would break or greatly slow down the current infrastructure for accessing `chandra_models` data.

Instead this PR provides a convenient mechanism to restore shared access for select git repos in CXC operations. In practice this is expected to apply only to the `chandra_models` shared repo. This implies that CXC users trust that the owners of the `chandra_models` repo to not be placing malicious content in the repo.

**If the user config does not permit safe access to the requested chandra_models repo then the user `~/.gitconfig` file will be updated (via `git config --global`) to mark that directory (and only that directory) as safe for access as a non-owner. A warning message to that effect is issued.**

On HEAD linux this typically results in adding the following two lines to `~/.gitconfig`:
```
[safe]
	directory = /proj/sot/ska/data/chandra_models
```

### Bonus function `utils.get_owner(path)`

I needed a platform-independent way to get the user name, which landed in `ska_helpers.utils`. l'm not sure if this is the only or best way, but it appears to work. Interestingly, if I ask for the owner of a VM-shared directory on Windows it returns `"Everyone"`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This may update the user's `~/.gitconfig`. See above.

## Testing 
<!-- If relevant describe any special setup for testing. -->

### Unit and functional tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (at 35991b8f)
- [x] Linux (on HEAD as user `aldcroft` with ska3-flight 2023.1 activated, otherwise vanilla) (at 35991b8f)
- [x] Windows (at 21ba07c)

#### Mac
```
ska_helpers/tests/test_git_helpers.py::test_make_git_repo_safe SKIPPED (Chandra models dir ownership is OK)                         [ 43%]
```
#### Linux HEAD
The relevant unit test ran to completion and passed (indicating it found a chandra_models with a different owner, verified the not safe condition and then fixed it):
```
ska_helpers/tests/test_git_helpers.py::test_make_git_repo_safe PASSED                                 [100%]
```
Note that four tests of `ska_helpers.chandra_models` failed due the git safe problem. To test correcting this I did:
```
ipython
>>> from ska_helpers.git_helpers import make_git_repo_safe
>>> from ska_helpers import paths
>>> make_git_repo_safe(paths.chandra_models_repo_path())
```
This produced the expected warning and updated my `~/.gitconfig` to add these two lines:
```
[safe]
	directory = /proj/sot/ska/data/chandra_models
```
After doing this then the original four failing tests now pass.

#### Windows
```
ska_helpers/tests/test_git_helpers.py::test_make_git_repo_safe PASSED                                            [100%]
```

Independent check of unit tests by Jean
- [X] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran this on Windows where every VM-shared repo is considered unsafe. For example:
```
In [6]: from ska_helpers.git_helpers import make_git_repo_safe

In [7]: make_git_repo_safe(r'y:\data\chandra_models')
<ipython-input-7-3979d908222d>:1: UserWarning: Updating git config to allow read-only git operations on trusted repository y:\data\chandra_models. Contact Ska team for questions.
  make_git_repo_safe(r'y:\data\chandra_models')

In [8]: make_git_repo_safe(r'y:\data\chandra_models')
# Second time it is already safe
```

OSX - JC - I can confirm that after changing the permission on /Users/jean/git/chandra_models that this worked as expected
```
In [1]: from ska_helpers.git_helpers import make_git_repo_safe

In [2]: make_git_repo_safe('/Users/jean/git/chandra_models')
<ipython-input-2-3a5454f91216>:1: UserWarning: Updating git config to allow read-only git operations on trusted repository /Users/jean/git/chandra_models. Contact Ska team for questions.
  make_git_repo_safe('/Users/jean/git/chandra_models')
```
And that the correct safe directory entry was added to my .gitconfig. 
