### PR TITLE
Chandra models caching and a generic LRUDict class (evict least recently used entries)

### DIFF
--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -126,6 +126,7 @@ def get_data(
     First we read the model specification for the ACA model. The ``get_data()`` function
     returns the text of the model spec so we need to use ``json.loads()`` to convert it
     to a dict.
+    ::
 
         >>> import json
         >>> from astropy.io import fits
@@ -138,6 +139,7 @@ def get_data(
 
     Next we read the acquisition probability model image. Since the image is a gzipped
     FITS file we need to use a helper function to read it.
+    ::
 
         >>> def read_fits_image(file_path):
         ...     with fits.open(file_path) as hdus:
@@ -149,7 +151,6 @@ def get_data(
         ...     read_func=read_fits_image
         ... )
         >>> acq_model_image.shape
-        ...
         (141, 31, 7)
 
     Now let's get the version of the chandra_models repository::
@@ -157,9 +158,9 @@ def get_data(
         >>> chandra_models.get_repo_version()
         '3.47'
 
-
     Finally get version 3.30 of the ACA model spec from GitHub. The use of a lambda
     function to read the JSON file is compact but not recommended for production code.
+    ::
 
         >>> model_spec_3_30, info = chandra_models.get_data(
         ...     "chandra_models/xija/aca/aca_spec.json",
@@ -180,8 +181,8 @@ def get_data(
         is used as the default. This is useful for testing.
     repo_path : str, Path
         Path to directory or URL containing chandra_models repository (default is
-        $SKA/data/chandra_models or either of the ``CHANDRA_MODELS_REPO_DIR`` or
-         ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW`` environment variables if set).
+        ``$SKA/data/chandra_models`` or either of the ``CHANDRA_MODELS_REPO_DIR`` or
+        ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW`` environment variables if set).
     require_latest_version : bool
         Require that ``version`` matches the latest release on GitHub
     timeout : int, float

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -16,6 +16,7 @@ import git
 import requests
 
 from ska_helpers.paths import chandra_models_repo_path
+from ska_helpers.utils import LRUDict
 
 __all__ = [
     "chandra_models_cache",
@@ -54,16 +55,15 @@ def chandra_models_cache(func):
             _, info = get_data("chandra_models/xija/aca/aca_spec.json", version=version)
             return info
     """
-    cache = {}
+    cache = LRUDict(capacity=32)
 
     @functools.wraps(func)
     def cached_func(*args, **kwargs):
         key = (
-            args
-            + tuple(sorted(kwargs.items()))
-            + tuple((name, os.environ.get(name)) for name in ENV_VAR_NAMES)
+            args,
+            tuple(sorted(kwargs.items())),
+            tuple((name, os.environ.get(name)) for name in ENV_VAR_NAMES),
         )
-        print(f"caching key: {key}")
         if key not in cache:
             cache[key] = func(*args, **kwargs)
 

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -270,13 +270,11 @@ def get_data(
                 "commit": repo.head.commit.hexsha,
                 "data_file_path": str(repo_file_path),
                 "repo_path": str(repo_path),
-                "CHANDRA_MODELS_DEFAULT_VERSION": os.environ.get(
-                    "CHANDRA_MODELS_DEFAULT_VERSION"
-                ),
-                "CHANDRA_MODELS_REPO_DIR": os.environ.get("CHANDRA_MODELS_REPO_DIR"),
                 "md5": md5,
             }
         )
+        for name in ENV_VAR_NAMES:
+            info[name] = os.environ.get(name)
 
     return data, info
 

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -116,10 +116,11 @@ def test_get_data_aca_3_30():
         },
         "version": "3.30",
         "commit": "94d2fa56bac1637cbfe63bcb1bc9294954379c11",
-        "CHANDRA_MODELS_DEFAULT_VERSION": None,
-        "CHANDRA_MODELS_REPO_DIR": None,
         "md5": "0e72b6402b8ed1fbaf81d5e79232461b",
     }
+    for name in chandra_models.ENV_VAR_NAMES:
+        exp[name] = os.environ.get(name)
+
     assert info == exp
 
 

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -26,6 +26,8 @@ except Exception:
 
 ACA_SPEC_PATH = "chandra_models/xija/aca/aca_spec.json"
 
+SOME_ENV_VAR_DEFINED = any(os.environ.get(nm) for nm in chandra_models.ENV_VAR_NAMES)
+
 
 def read_xija_spec(fn):
     with open(fn) as fh:
@@ -160,6 +162,7 @@ def test_get_data_extra_kwargs():
     assert acq_model_image.shape == (141, 31, 7)
 
 
+@pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Non flight repo is being used")
 def test_get_data_aca_latest():
     # Latest version
     spec, info = chandra_models.get_data(
@@ -207,6 +210,7 @@ def test_get_repo_version():
     assert re.match(r"^[0-9.]+$", version)
 
 
+@pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Non flight repo is being used")
 @pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
 def test_check_github_version():
     version = chandra_models.get_repo_version()

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import contextlib
 import json
 import os
 import re
@@ -12,6 +11,7 @@ import requests
 from astropy.io import fits
 
 from ska_helpers import chandra_models
+from ska_helpers.utils import temp_env_var
 
 try:
     # Fast request to see if GitHub is available
@@ -31,19 +31,6 @@ def read_xija_spec(fn):
     with open(fn) as fh:
         spec = json.load(fh)
     return spec, fn
-
-
-@contextlib.contextmanager
-def temp_env_var(name, value):
-    original_value = os.environ.get(name)
-    os.environ[name] = value
-    try:
-        yield
-    finally:
-        if original_value is not None:
-            os.environ[name] = original_value
-        else:
-            del os.environ[name]
 
 
 @chandra_models.chandra_models_cache

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -164,7 +164,8 @@ def test_get_data_extra_kwargs():
 
 @pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Non flight repo is being used")
 def test_get_data_aca_latest():
-    # Latest version
+    # If any env vars are set that select a non-flight version of the repo then we have
+    # no expectation that the version of that repo will match github, so skip this test.
     spec, info = chandra_models.get_data(
         ACA_SPEC_PATH, require_latest_version=HAS_GITHUB, read_func=read_xija_spec
     )
@@ -213,6 +214,8 @@ def test_get_repo_version():
 @pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Non flight repo is being used")
 @pytest.mark.skipif(not HAS_GITHUB, reason="GitHub not available")
 def test_check_github_version():
+    # If any env vars are set that select a non-flight version of the repo then we have
+    # no expectation that the version of that repo will match github, so skip this test.
     version = chandra_models.get_repo_version()
     status = chandra_models.get_github_version() == version
     assert status is True

--- a/ska_helpers/tests/test_paths.py
+++ b/ska_helpers/tests/test_paths.py
@@ -7,7 +7,12 @@ import pytest
 
 from ska_helpers import paths
 
+SOME_ENV_VAR_DEFINED = any(
+    os.environ.get(nm) for nm in paths.CHANDRA_MODELS_ROOT_ENV_VARS
+)
 
+
+@pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Test requires clean environment")
 @pytest.mark.parametrize("repo_source", ["default", "env", "kwargs"])
 @pytest.mark.parametrize("chandra_models_repo_dir", paths.CHANDRA_MODELS_ROOT_ENV_VARS)
 def test_chandra_models_paths(repo_source, chandra_models_repo_dir, monkeypatch):

--- a/ska_helpers/tests/test_paths.py
+++ b/ska_helpers/tests/test_paths.py
@@ -7,23 +7,21 @@ import pytest
 
 from ska_helpers import paths
 
-SOME_ENV_VAR_DEFINED = any(
-    os.environ.get(nm) for nm in paths.CHANDRA_MODELS_ROOT_ENV_VARS
-)
 
-
-@pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Test requires clean environment")
 @pytest.mark.parametrize("repo_source", ["default", "env", "kwargs"])
 @pytest.mark.parametrize("chandra_models_repo_dir", paths.CHANDRA_MODELS_ROOT_ENV_VARS)
 def test_chandra_models_paths(repo_source, chandra_models_repo_dir, monkeypatch):
+    if repo_source in ["env", "default"]:
+        # For these two cases we need a clean env as a baseline in order to know the
+        # expected result.
+        for env_var in paths.CHANDRA_MODELS_ROOT_ENV_VARS:
+            monkeypatch.delenv(env_var, raising=False)
+
     if repo_source == "env":
         root = Path("/", "foo", "chandra_models")
         monkeypatch.setenv(chandra_models_repo_dir, str(root))
         kwargs = {}
     elif repo_source == "default":
-        # Make sure no path-changing env vars are set
-        for env_var in paths.CHANDRA_MODELS_ROOT_ENV_VARS:
-            monkeypatch.delenv(env_var, raising=False)
         root = Path(os.environ["SKA"]) / "data" / "chandra_models"
         kwargs = {}
     elif repo_source == "kwargs":

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,9 +1,10 @@
+import os
 import pickle
 import time
 
 import pytest
 
-from ska_helpers.utils import LazyDict, LazyVal, LRUDict, lru_cache_timed
+from ska_helpers.utils import LazyDict, LazyVal, LRUDict, lru_cache_timed, temp_env_var
 
 
 def load_func(a, b, c=None):
@@ -104,3 +105,16 @@ def test_lru_dict():
     # Access the remaining items in order
     assert d["b"] == 2
     assert d["d"] == 4
+
+
+def test_temp_env_var():
+    name = "ASDF1234_asdfsdaf_982398239324223423_a2323423424211111_adfaASDfaSDFASDF"
+    # Check that the environment variable is initially unset
+    assert os.environ.get(name) is None
+
+    # Set the environment variable using the context manager
+    with temp_env_var(name, "my_value"):
+        assert os.environ.get(name) == "my_value"
+
+    # Check that the environment variable is unset after the context manager exits
+    assert os.environ.get(name) is None

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,7 +1,9 @@
 import pickle
 import time
 
-from ska_helpers.utils import LazyDict, LazyVal, lru_cache_timed
+import pytest
+
+from ska_helpers.utils import LazyDict, LazyVal, LRUDict, lru_cache_timed
 
 
 def load_func(a, b, c=None):
@@ -63,3 +65,42 @@ def test_lru_cache_timed():
     assert test.cache_info().currsize == 2
     time.sleep(0.11)
     assert test.cache_info().currsize == 0
+
+
+def test_lru_dict():
+    # Create an LRUDict with capacity 2
+    d = LRUDict(2)
+
+    # Add two items to the dict
+    d["a"] = 1
+    d["b"] = 2
+
+    # Access the items in order
+    assert d["a"] == 1
+    assert d["b"] == 2
+
+    # Add a third item to the dict
+    d["c"] = 3
+
+    # The oldest item ("a") should have been evicted
+    with pytest.raises(KeyError):
+        d["a"]
+
+    # Access the remaining items in order
+    assert d["b"] == 2
+    assert d["c"] == 3
+
+    # Access the items in reverse order
+    assert d["c"] == 3
+    assert d["b"] == 2
+
+    # Add a fourth item to the dict
+    d["d"] = 4
+
+    # The oldest item ("c") should have been evicted
+    with pytest.raises(KeyError):
+        d["c"]
+
+    # Access the remaining items in order
+    assert d["b"] == 2
+    assert d["d"] == 4

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import functools
+from collections import OrderedDict
 
 __all__ = ["LazyDict", "LazyVal"]
 
@@ -198,3 +199,22 @@ def lru_cache_timed(maxsize=128, typed=False, timeout=3600):
         return _wrapped
 
     return _wrapper
+
+
+class LRUDict(OrderedDict):
+    def __init__(self, capacity=128):
+        super().__init__()
+        self.capacity = capacity
+
+    def __getitem__(self, key):
+        value = super().__getitem__(key)
+        self.move_to_end(key)
+        return value
+
+    def __setitem__(self, key, value):
+        if key in self:
+            self.move_to_end(key)
+        super().__setitem__(key, value)
+        if len(self) > self.capacity:
+            oldest = next(iter(self))
+            del self[oldest]

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -209,25 +209,27 @@ class LRUDict(OrderedDict):
 
     Inherits from collections.OrderedDict to maintain the order of insertion.
 
+    Examples:
+    ---------
+    ::
+
+        >>> d = LRUDict(2)
+        >>> d["a"] = 1
+        >>> d["b"] = 2
+        >>> d["c"] = 3
+        >>> list(d.keys())
+        ['b', 'c']
+        >>> d["b"]
+        2
+        >>> d["a"]
+        Traceback (most recent call last):
+            ...
+        KeyError: 'a'
+
     Parameters:
     -----------
     capacity : int, optional
         The maximum number of items that the dictionary can hold. Defaults to 128.
-
-    Examples:
-    ---------
-    >>> d = LRUDict(2)
-    >>> d["a"] = 1
-    >>> d["b"] = 2
-    >>> d["c"] = 3
-    >>> list(d.keys())
-    ['b', 'c']
-    >>> d["b"]
-    2
-    >>> d["a"]
-    Traceback (most recent call last):
-        ...
-    KeyError: 'a'
     """
 
     def __init__(self, capacity=128):

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -202,6 +202,32 @@ def lru_cache_timed(maxsize=128, typed=False, timeout=3600):
 
 
 class LRUDict(OrderedDict):
+    """
+    Dict that maintains a fixed capacity and evicts least recently used item when full.
+
+    Inherits from collections.OrderedDict to maintain the order of insertion.
+
+    Parameters:
+    -----------
+    capacity : int, optional
+        The maximum number of items that the dictionary can hold. Defaults to 128.
+
+    Examples:
+    ---------
+    >>> d = LRUDict(2)
+    >>> d["a"] = 1
+    >>> d["b"] = 2
+    >>> d["c"] = 3
+    >>> list(d.keys())
+    ['b', 'c']
+    >>> d["b"]
+    2
+    >>> d["a"]
+    Traceback (most recent call last):
+        ...
+    KeyError: 'a'
+    """
+
     def __init__(self, capacity=128):
         super().__init__()
         self.capacity = capacity

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -3,7 +3,7 @@
 import functools
 from collections import OrderedDict
 
-__all__ = ["LazyDict", "LazyVal"]
+__all__ = ["LazyDict", "LazyVal", "LRUDict", "lru_cache_timed"]
 
 
 def _lazy_load_wrap(unbound_method):

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -1,9 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import contextlib
 import functools
+import os
 from collections import OrderedDict
 
-__all__ = ["LazyDict", "LazyVal", "LRUDict", "lru_cache_timed"]
+__all__ = ["LazyDict", "LazyVal", "LRUDict", "lru_cache_timed", "temp_env_var"]
 
 
 def _lazy_load_wrap(unbound_method):
@@ -244,3 +246,35 @@ class LRUDict(OrderedDict):
         if len(self) > self.capacity:
             oldest = next(iter(self))
             del self[oldest]
+
+
+@contextlib.contextmanager
+def temp_env_var(name, value):
+    """
+    A context manager that temporarily sets an environment variable.
+
+    Example::
+
+        >>> os.environ.get("MY_VARIABLE")
+        None
+        >>> with temp_env_var("MY_VARIABLE", "my_value"):
+        ...     os.environ.get("MY_VARIABLE")
+        ...
+        'my_value'
+        >>> os.environ.get("MY_VARIABLE")
+        None
+
+    :param name: str
+        Name of the environment variable to set.
+    :param value: str
+        Value to set the environment variable to.
+    """
+    original_value = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if original_value is not None:
+            os.environ[name] = original_value
+        else:
+            del os.environ[name]


### PR DESCRIPTION
## Description

This adds three things:

- Decorator to cache outputs for a function that gets chandra_models data.
- Dict that maintains a fixed capacity and evicts least recently used item when full.
- Context manager to temporarily set an environment variable. Useful in testing when the scope is local and `pytest.monkeypatch.setenv` won't work.

The main event is the decorator which is intended to allow efficient caching of function calls to get data from chandra_models. The main feature is that it pays attention to environment variables that might impact the function output. 

The secondary functions seem useful to expose. They were 90% generated (including docs and tests) with Copilot, so the effort was low.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a class, a decorator, and a context manager to the public API.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new unit tests)

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
