### PR TITLE
Add the repo dir to safe config if used directly

### DIFF
--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -91,8 +91,8 @@ def get_local_repo(repo_path, version):
         if version is not None:
             repo.git.checkout(version)
     else:
-        make_git_repo_safe(repo_path)
         repo = git.Repo(repo_path)
+        make_git_repo_safe(repo_path)
         repo_path_local = repo_path
 
     yield repo, repo_path_local

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -15,6 +15,7 @@ import git
 import requests
 
 from ska_helpers.paths import chandra_models_repo_path
+from ska_helpers.git_helpers import make_git_repo_safe
 
 __all__ = [
     "get_data",
@@ -45,6 +46,7 @@ def get_local_repo(repo_path, version):
         if version is not None:
             repo.git.checkout(version)
     else:
+        make_git_repo_safe(repo_path)
         repo = git.Repo(repo_path)
         repo_path_local = repo_path
 


### PR DESCRIPTION
## Description
Add the repo dir to safe config if used directly. 

## Interface impacts
Updates the user's gitconfig and throws a UserWarning if code is called that uses a chandra_models repo that is not owned by the user.
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (tested at d805180)

Independent check of unit tests by @taldcroft
- [x] Linux (see https://github.com/sot/ska_helpers/pull/37#issuecomment-1630988347)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I configured my chandra_models repo to again be owned by not-me, pytest ran the drift model test out of chandra_aca, and confirmed the UserWarning and the chandra_models repo added to the safe directory of my .gitconfig.  I suppose we need an additional functional test that this works correctly if the model version is specified.

Also @taldcroft, see https://github.com/sot/ska_helpers/pull/37#issuecomment-1630988347.
