### PR TITLE
Remove the check on repo tip being at the latest tag

### DIFF
--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -313,8 +313,6 @@ def get_repo_version(
 
     tags = sorted(repo.tags, key=lambda tag: tag.commit.committed_datetime)
     tag_repo = tags[-1]
-    if tag_repo.commit != repo.head.commit:
-        raise ValueError(f"repo tip is not at tag {tag_repo}")
 
     return tag_repo.name
 


### PR DESCRIPTION
## Description

Since we maintain the flight chandra_models repo carefully and have processes in place to ensure its integrity, this PR removes the check that the current tip is at the latest tag. This seems to cause more problems than it solves.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I checked out chandra_models at 3.48 and ran tests from master and no-repo-tip-check to confirm that the tests no longer FAIL on the tip mismatch.

```
========================================================== short test summary info ===========================================================
FAILED ska_helpers/tests/test_chandra_models.py::test_get_data_extra_kwargs - ValueError: repo tip is not at tag 3.49
FAILED ska_helpers/tests/test_chandra_models.py::test_get_repo_version - ValueError: repo tip is not at tag 3.49
================================================== 2 failed, 38 passed, 3 skipped in 6.44s ===================================================
(ska3-matlab-2023.4rc6) spark:ska_helpers jean$ git checkout no-repo-tip-check
Switched to branch 'no-repo-tip-check'
Your branch is up to date with 'origin/no-repo-tip-check'.
(ska3-matlab-2023.4rc6) spark:ska_helpers jean$ pytest
============================================================ test session starts =============================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jean/git/ska_helpers
plugins: timeout-2.1.0, anyio-3.6.2
collected 43 items                                                                                                                           

ska_helpers/retry/tests/test_retry.py ..........                                                                                       [ 23%]
ska_helpers/tests/test_chandra_models.py .........s....s..                                                                             [ 62%]
ska_helpers/tests/test_git_helpers.py s                                                                                                [ 65%]
ska_helpers/tests/test_paths.py ......                                                                                                 [ 79%]
ska_helpers/tests/test_run_info.py ..                                                                                                  [ 83%]
ska_helpers/tests/test_utils.py .......                                                                                                [100%]

======================================================= 40 passed, 3 skipped in 6.18s ========================================================
```