### PR TITLE
clear git_helpers.make_git_repo_safe cache in test

### DIFF
--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -27,6 +27,7 @@ def ska_ownership_ok():
 )
 @pytest.mark.skipif(ska_ownership_ok(), reason="Chandra models dir ownership is OK")
 def test_make_git_repo_safe(monkeypatch):
+    git_helpers.make_git_repo_safe.cache_clear()
     with tempfile.TemporaryDirectory() as tempdir:
         # temporarily set HOME to a temp dir so .gitconfig comes from there
         monkeypatch.setenv("HOME", tempdir)

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -27,7 +27,9 @@ def ska_ownership_ok():
 )
 @pytest.mark.skipif(ska_ownership_ok(), reason="Chandra models dir ownership is OK")
 def test_make_git_repo_safe(monkeypatch):
+    # Clear the 'repo_safe' cache so that this test always has something to do.
     git_helpers.make_git_repo_safe.cache_clear()
+
     with tempfile.TemporaryDirectory() as tempdir:
         # temporarily set HOME to a temp dir so .gitconfig comes from there
         monkeypatch.setenv("HOME", tempdir)


### PR DESCRIPTION
## Description

Clear git_helpers.make_git_repo_safe cache in test, otherwise the test fails, because the function can be called from another place before.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by Jean
- [x] Linux from 2023.3rc4 candidate
- [x] OSX from 2023.3rc4 (with CHANDRA_MODELS_REPO_DIR set to a directory owned by not-me.  This skips some of the test_chandra_models.py tests but runs the test_git_helpers test). 

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
