### PR TITLE
Only do the repo_safe logic on linux and osx for now

### DIFF
--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 import git
 import requests
 
+from testr.test_helper import is_linux, is_mac
 from ska_helpers.paths import chandra_models_repo_path
 from ska_helpers.git_helpers import make_git_repo_safe
 from ska_helpers.utils import LRUDict
@@ -92,7 +93,8 @@ def get_local_repo(repo_path, version):
             repo.git.checkout(version)
     else:
         repo = git.Repo(repo_path)
-        make_git_repo_safe(repo_path)
+        if is_linux() or is_mac():
+            make_git_repo_safe(repo_path)
         repo_path_local = repo_path
 
     yield repo, repo_path_local


### PR DESCRIPTION
## Description
Only do the repo_safe logic on linux and osx for now

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This deals with an issue that it looks like the windows matlab pyexec does not execute the subprocess git checks in git_helpers well.  The windows chandra_models repo should be owned by user anyway, so except for the constructed case of it being on a vm mount, this should be acceptable too.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
