### PR TITLE
Replace git_helpers subprocess with gitpython and revert #41

### DIFF
--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 import git
 import requests
 
+from ska_helpers.git_helpers import make_git_repo_safe
 from ska_helpers.paths import chandra_models_repo_path
 from ska_helpers.utils import LRUDict
 
@@ -91,6 +92,7 @@ def get_local_repo(repo_path, version):
             repo.git.checkout(version)
     else:
         repo = git.Repo(repo_path)
+        make_git_repo_safe(repo_path)
         repo_path_local = repo_path
 
     yield repo, repo_path_local

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -78,6 +78,8 @@ def _handle_git_rev_parse_failure(path: Path, proc_err: git.exc.GitCommandError)
 
         # Run the git config command to add this repo as a safe directory.
         # Use stdin=DEVNULL to avoid issues with no stdin from matlab pyexec.
-        subprocess.check_call(cmds, stdin=subprocess.DEVNULL)
+        subprocess.check_call(
+            cmds, stdin=subprocess.DEVNULL, creationflags=subprocess.CREATE_NO_WINDOW
+        )
     else:
         raise proc_err

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -78,6 +78,9 @@ def _handle_git_status_failure(path: Path, proc_err: git.exc.GitCommandError):
             f"trusted repository {path}. Contact Ska team for questions.",
             stacklevel=3,
         )
-        subprocess.check_call(cmds)
+
+        # Run the git config command to add this repo as a safe directory.
+        # Use stdin=DEVNULL to avoid issues with no stdin from matlab pyexec.
+        subprocess.check_call(cmds, stdin=subprocess.DEVNULL)
     else:
         raise proc_err

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -36,15 +36,15 @@ def make_git_repo_safe(path: str | Path) -> None:
 
     repo = git.Repo(path)
     try:
-        repo.git.status()
+        repo.git.rev_parse()
     except git.exc.GitCommandError as err:
-        _handle_git_status_failure(path, err)
+        _handle_git_rev_parse_failure(path, err)
         # Ensure that the repo is now safe. This will raise an exception
         # otherwise.
-        repo.git.status()
+        repo.git.rev_parse()
 
 
-def _handle_git_status_failure(path: Path, proc_err: git.exc.GitCommandError):
+def _handle_git_rev_parse_failure(path: Path, proc_err: git.exc.GitCommandError):
     """Handle a failure of `git status` command.
 
     This is most likely due to repo not being safe. If that is the case (based

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -6,11 +6,8 @@ import functools
 import git
 import re
 import subprocess
-import sys
 import warnings
 from pathlib import Path
-
-from ska_file import chdir
 
 
 __all__ = ["make_git_repo_safe"]

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -5,7 +5,6 @@ Helper functions for using git.
 import functools
 import git
 import re
-import subprocess
 import warnings
 from pathlib import Path
 
@@ -76,10 +75,10 @@ def _handle_git_rev_parse_failure(path: Path, proc_err: git.exc.GitCommandError)
             stacklevel=3,
         )
 
+        path_from_error = cmds[-1]
+
         # Run the git config command to add this repo as a safe directory.
-        # Use stdin=DEVNULL to avoid issues with no stdin from matlab pyexec.
-        subprocess.check_call(
-            cmds, stdin=subprocess.DEVNULL, creationflags=subprocess.CREATE_NO_WINDOW
-        )
+        repo = git.Repo(path)
+        repo.git.config("--global", "--add", "safe.directory", path_from_error)
     else:
         raise proc_err


### PR DESCRIPTION
## Description

Set ska_helpers.chandra_models to use make_git_repo_safe for the chandra_models repository.  (We removed this in 0.10.3).

Use gitpython to determine if a repo is safe in git_helpers and use gitpython's config to add an unsafe directory to the config instead of a subprocess call.

The motivation for these changes is that with release https://github.com/sot/ska_helpers/releases/tag/0.10.2 , which called make_git_repo_safe on the chandra_models directory for the drift and acquisition models, FOT MATLAB testing showed all subprocess calls failing with windows errors:
```
Error executing python statement: 'proc = subprocess.run(["git", "rev-parse"], capture_output=True)' - [WinError 6] The handle is invalid
```

This PR originally used a suggestion from [stackoverflow](https://stackoverflow.com/questions/40108816/python-running-as-windows-service-oserror-winerror-6-the-handle-is-invalid) to set stdin to subprocess.DEVNULL in any subprocess calls.  The error message we were getting looked similar and the fix appears to work on windows matlab pyexec and not cause problems in testing on our other systems.  However it looks like the subprocess call can be avoided.

This PR removes the subprocess calls and replaces with gitpython.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
- [x] Linux 

Independent check of unit tests by Javier (according to comments)
- [x] Windows

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Tested from Windows VM with Matlab and pyexec at commit [c542ebc](https://github.com/sot/ska_helpers/pull/42/commits/c542ebc086126577c88166a942bc3be76c0ac1ef)

With c:\\chandra_models set to a repo owned by another user and with no .gitconfig for the running user, I did:

```
>> pyexec('import sys')
PYEXEC: Using custom python program name: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\python.exe
        and python home: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing
>> pyexec('sys.path.insert(0, "C:\\Users\\unksm\\git\\ska_helpers")')
>> pyexec('import ska_helpers.git_helpers')
```
That import shows a bunch of content at stderr, but I believe this to be benign as only related to determining a dev version label for ska_helpers when imported from the git repo.

```
PYPROC(stderr): Traceback (most recent call last):
PYPROC(stderr):   File "C:\Users\unksm\git\ska_helpers\ska_helpers\version.py", line 114, in get_version
PYPROC(stderr):     assert ok
PYPROC(stderr): AssertionError
PYPROC(stderr): 
PYPROC(stderr): During handling of the above exception, another exception occurred:
PYPROC(stderr): 
PYPROC(stderr): Traceback (most recent call last):
PYPROC(stderr):   File "C:\Users\unksm\git\ska_helpers\ska_helpers\version.py", line 148, in get_version
PYPROC(stderr):     version = get_version(root=Path(*roots), relative_to=module_file)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\__init__.py", line 146, in get_version
PYPROC(stderr):     maybe_version = _get_version(config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\__init__.py", line 153, in _get_version
PYPROC(stderr):     parsed_version = _do_parse(config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\__init__.py", line 100, in _do_parse
PYPROC(stderr):     version = _version_from_entrypoints(config) or _version_from_entrypoints(
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\_entrypoints.py", line 66, in _version_from_entrypoints
PYPROC(stderr):     version: ScmVersion | None = _call_entrypoint_fn(root, config, ep.load())
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\_entrypoints.py", line 40, in _call_entrypoint_fn
PYPROC(stderr):     return fn(root, config=config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\git.py", line 179, in parse
PYPROC(stderr):     wd = get_working_directory(config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\git.py", line 159, in get_working_directory
PYPROC(stderr):     return GitWorkdir.from_potential_worktree(config.parent)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\git.py", line 54, in from_potential_worktree
PYPROC(stderr):     require_command(cls.COMMAND)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\utils.py", line 171, in require_command
PYPROC(stderr):     raise OSError("%r was not found" % name)
PYPROC(stderr): OSError: 'git' was not found
PYPROC(stderr): 
PYPROC(stderr): 
PYPROC(stderr): 
PYPROC(stderr): Failed to find a package version, setting to 0.0.0
PYPROC(stderr): ********************************************************************************
PYPROC(stderr): Getting version for package=ska_helpers distribution=None 
PYPROC(stderr):   Current directory: C:\Users\unksm\git\ska_helpers
PYPROC(stderr):   sys.path=['C:\\Users\\unksm\\git\\ska_helpers', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\python310.zip', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\DLLs', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_interface_testing\\private', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages\\win32', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages\\win32\\lib', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages\\Pythonwin']
PYPROC(stderr):   module_file='C:\\Users\\unksm\\git\\ska_helpers\\ska_helpers\\__init__.py'
PYPROC(stderr):   Getting distribution dist_info=get_distribution(ska_helpers)
PYPROC(stderr):     dist_info.location='c:\\users\\unksm\\documents\\matlab\\fot_tools\\python\\python3_windows_64bit_testing\\lib\\site-packages'
PYPROC(stderr):     dist_info.version='0.10.3'
PYPROC(stderr):     WARNING: distinfo.location does not match module_file, falling through to setuptools_scm
PYPROC(stderr):   Getting version via setuptools_scm for git repo
PYPROC(stderr):     Running get_version(
PYPROC(stderr):         root=..,
PYPROC(stderr):         relative_to=C:\Users\unksm\git\ska_helpers\ska_helpers\__init__.py
PYPROC(stderr):     )
PYPROC(stderr): WARNING: got version='0.0.0'
PYPROC(stderr): ********************************************************************************
PYPROC(stderr): 
```
After import, using make_git_repo_safe appears to work correctly
```
>> pyexec('ska_helpers.git_helpers.make_git_repo_safe("C:\\chandra_models")')
PYPROC(stderr): Updating git config to allow read-only git operations on trusted repository C:\chandra_models. Contact Ska team for questions.
>> 
```
And I confirmed the text of `~/.gitconfig` is 
```
[safe]
	directory = C:/chandra_models
```
And repeat of the process does not show the warning.






