### PR TITLE
Provide Windows-specific wrappers for subprocess funcs and revert #41

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,13 @@ Setup Helpers
    :members:
 
 
+Subprocess on Windows
+---------------------
+
+.. automodule:: ska_helpers.subprocess_win
+   :members:
+
+
 Utilities
 ---------
 

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -16,6 +16,7 @@ import git
 import requests
 
 from ska_helpers.paths import chandra_models_repo_path
+from ska_helpers.git_helpers import make_git_repo_safe
 from ska_helpers.utils import LRUDict
 
 __all__ = [
@@ -91,6 +92,7 @@ def get_local_repo(repo_path, version):
             repo.git.checkout(version)
     else:
         repo = git.Repo(repo_path)
+        make_git_repo_safe(repo_path)
         repo_path_local = repo_path
 
     yield repo, repo_path_local

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from ska_file import chdir
 
+from ska_helpers import subprocess_win
 
 __all__ = ["make_git_repo_safe"]
 
@@ -38,12 +39,12 @@ def make_git_repo_safe(path: str | Path) -> None:
 
     with chdir(path):
         # Run a lightweight command which will fail for an unsafe repo
-        proc = subprocess.run(["git", "rev-parse"], capture_output=True)
+        proc = subprocess_win.run(["git", "rev-parse"], capture_output=True)
         if proc.returncode != 0:
             _handle_rev_parse_failure(path, proc)
             # Ensure that the repo is now safe. This will raise an exception
             # otherwise.
-            subprocess.check_call(["git", "rev-parse"])
+            subprocess_win.check_call(["git", "rev-parse"])
 
 
 def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
@@ -78,7 +79,7 @@ def _handle_rev_parse_failure(path: Path, proc: subprocess.CompletedProcess):
             f"trusted repository {path}. Contact Ska team for questions.",
             stacklevel=3,
         )
-        subprocess.check_call(cmds)
+        subprocess_win.check_call(cmds)
     else:
         print(err, file=sys.stderr)
         proc.check_returncode()

--- a/ska_helpers/subprocess_win.py
+++ b/ska_helpers/subprocess_win.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Fix subprocess high-level functions on Windows.
+"""Fix subprocess high-level functions on Windows via MATLAB pyexec().
 
 For the subprocess functions ``run``, ``call``, ``check_call``, and ``check_output``,
 this module defines thin wrappers that change the following argument defaults to fix
@@ -10,7 +10,18 @@ issues on Windows:
 
 On non-Windows platforms these wrappers are no-ops.
 
-See discussion https://github.com/sot/ska_helpers/pull/42 for details.
+See also discussion in https://github.com/sot/ska_helpers/pull/42.
+
+The ``stdin`` fix addresses this exception:
+```
+>> pyexec('proc = subprocess.run(["git", "rev-parse"], capture_output=True)')
+  ...
+PYPROC: Error executing python statement: 'proc = subprocess.run(["git", "rev-parse"],
+        capture_output=True)' - [WinError 6] The handle is invalid
+```
+
+The ``creationflags`` fix addresses the problem of a console window popping up when
+running a subprocess command within the MATLAB environment.
 """
 import functools
 import subprocess

--- a/ska_helpers/subprocess_win.py
+++ b/ska_helpers/subprocess_win.py
@@ -1,0 +1,44 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Fix subprocess high-level functions on Windows.
+
+For the subprocess functions ``run``, ``call``, ``check_call``, and ``check_output``,
+this module defines thin wrappers that change the following argument defaults to fix
+issues on Windows:
+
+- ``stdin`` is set to ``subprocess.DEVNULL`` if not specified.
+- ``creationflags`` has the ``subprocess.CREATE_NO_WINDOW`` flag set.
+
+On non-Windows platforms these wrappers are no-ops.
+
+See discussion https://github.com/sot/ska_helpers/pull/42 for details.
+"""
+import functools
+import subprocess
+
+from testr.test_helper import is_windows
+
+__all__ = ["run", "call", "check_call", "check_output"]
+
+
+def fix_windows_subprocess(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if is_windows():
+            if "stdin" not in kwargs:
+                kwargs["stdin"] = subprocess.DEVNULL
+
+            if "creationflags" in kwargs:
+                kwargs["creationflags"] |= subprocess.CREATE_NO_WINDOW
+            else:
+                kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+# Fix subprocess high-level functions on Windows
+run = fix_windows_subprocess(subprocess.run)
+call = fix_windows_subprocess(subprocess.call)
+check_call = fix_windows_subprocess(subprocess.check_call)
+check_output = fix_windows_subprocess(subprocess.check_output)


### PR DESCRIPTION
## Description

This provides a generalized way to (hopefully) use `subprocess` successfully on Windows via the MATLAB `pyexec` interface.

It also reverts #41 since it fixes the problem that required the patch.

This is an alternative to #42.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds new versions of `subprocess` functions that should be Windows-safe.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
Coverage of two of the new functions is via existing unit tests in this package.
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Needs functional testing by @jeanconn in MATLAB.

