### PR TITLE
Skip git safe test on old git

### DIFF
--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import getpass
 import tempfile
+from packaging.version import Version
 
 import git
 import pytest
@@ -23,9 +24,10 @@ def ska_ownership_ok():
 
 def git_version_old():
     # Is the git version too old to have the repo_safe feature?
-    # This is the version of git not gitpython.
-    repo = git.Repo(CHANDRA_MODELS)
-    return repo.git.version_info < (2, 35, 2)
+    # The safe checking feature was added in git 2.35.2.
+    # This Git().version_info is the version of git not gitpython.
+    git_version = ".".join(str(val) for val in git.Git().version_info)
+    return Version(git_version) < Version("2.35.2")
 
 
 @pytest.mark.skipif(

--- a/ska_helpers/tests/test_git_helpers.py
+++ b/ska_helpers/tests/test_git_helpers.py
@@ -21,11 +21,19 @@ def ska_ownership_ok():
         return False
 
 
+def git_version_old():
+    # Is the git version too old to have the repo_safe feature?
+    # This is the version of git not gitpython.
+    repo = git.Repo(CHANDRA_MODELS)
+    return repo.git.version_info < (2, 35, 2)
+
+
 @pytest.mark.skipif(
     not CHANDRA_MODELS.exists(),
     reason="Chandra models dir is not there",
 )
 @pytest.mark.skipif(ska_ownership_ok(), reason="Chandra models dir ownership is OK")
+@pytest.mark.skipif(git_version_old(), reason="Git version is too old to care")
 def test_make_git_repo_safe(monkeypatch):
     # Clear the 'repo_safe' cache so that this test always has something to do.
     git_helpers.make_git_repo_safe.cache_clear()


### PR DESCRIPTION
## Description
Skip git safe test on old git

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
The test failure on GRETA with git 2.18.1 (test fails to throw expected error) suggests that the test should be skipped on old git. 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
- [x] GRETA linux on chimchim

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Test is appropriately skipped with correct comment on GRETA linux chimchim.
