### PR TITLE
Remove extra repo from git config command

### DIFF
--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -77,8 +77,7 @@ def _handle_git_rev_parse_failure(path: Path, proc_err: git.exc.GitCommandError)
 
         path_from_error = cmds[-1]
 
-        # Run the git config command to add this repo as a safe directory.
-        repo = git.Repo(path)
-        repo.git.config("--global", "--add", "safe.directory", path_from_error)
+        # Run the git config command to add the error repo path as a safe directory.
+        git.Git().config("--global", "--add", "safe.directory", path_from_error)
     else:
         raise proc_err


### PR DESCRIPTION
## Description

Clean up git config setting command to remove extra "repo".


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functionally, I removed the safe.directory from my osx .gitconfig and confirmed make_git_repo_safe spit out a warning and updated the config.  
