### PR TITLE
Skip is_dirty check from matlab tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     - id: black
       language_version: python3.10

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -123,7 +123,7 @@ def get_data(
       developement branch to test a model file update with applications like yoshi where
       specifying a version would require a long chain of API updates.
 
-    ``THERMAL_MODESL_DIR_FOR_MATLAB_TOOLS_SW`` is used to define the chandra_models repository
+    ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW`` is used to define the chandra_models repository
     location when running in the MATLAB tools software environment.  If this environment
     variable is set, then the git is_dirty() check of the chandra_models directory is skipped
     as the chandra_models repository is verified via SVN in the MATLAB tools software environment.

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -310,8 +310,13 @@ def get_repo_version(
             repo_path = chandra_models_repo_path()
         repo = git.Repo(repo_path)
 
-    if repo.is_dirty():
-        raise ValueError("repo is dirty")
+    # Use the THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW environment variable as a proxy
+    # to determine if we are running in the MATLAB tools software environment. If so
+    # the repo will not be dirty and using is_dirty() will touch a lock that will cause
+    # SVN to mark the directory as modified.
+    if os.environ.get('THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW') is None:
+        if repo.is_dirty():
+            raise ValueError("repo is dirty")
 
     tags = sorted(repo.tags, key=lambda tag: tag.commit.committed_datetime)
     tag_repo = tags[-1]

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -114,7 +114,7 @@ def get_data(
     """
     Get data from chandra_models repository.
 
-    For testing purposes there are three environment variables that impact the behavior:
+    There are three environment variables that impact the behavior:
 
     - ``CHANDRA_MODELS_REPO_DIR`` or ``THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW``:
       override the default root for the chandra_models repository
@@ -122,6 +122,15 @@ def get_data(
       this to a fixed version in unit tests (e.g. with ``monkeypatch``), or set to a
       developement branch to test a model file update with applications like yoshi where
       specifying a version would require a long chain of API updates.
+
+    ``THERMAL_MODESL_DIR_FOR_MATLAB_TOOLS_SW`` is used to define the chandra_models repository
+    location when running in the MATLAB tools software environment.  If this environment
+    variable is set, then the git is_dirty() check of the chandra_models directory is skipped
+    as the chandra_models repository is verified via SVN in the MATLAB tools software environment.
+    Users in the FOT Matlab tools should exercise caution if using locally-modified files
+    for testing, as the version information reported by this function in that case will not
+    be correct.
+
 
     Examples
     --------

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -321,8 +321,8 @@ def get_repo_version(
 
     # Use the THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW environment variable as a proxy
     # to determine if we are running in the MATLAB tools software environment. If so
-    # the repo will not be dirty and using is_dirty() will touch a lock that will cause
-    # SVN to mark the directory as modified.
+    # the repo will be checked via SVN and using is_dirty() would change the .git/index
+    # and cause SVN to mark the directory as modified. So skip is_dirty() in this case.
     if os.environ.get("THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW") is None:
         if repo.is_dirty():
             raise ValueError("repo is dirty")

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -314,7 +314,7 @@ def get_repo_version(
     # to determine if we are running in the MATLAB tools software environment. If so
     # the repo will not be dirty and using is_dirty() will touch a lock that will cause
     # SVN to mark the directory as modified.
-    if os.environ.get('THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW') is None:
+    if os.environ.get("THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW") is None:
         if repo.is_dirty():
             raise ValueError("repo is dirty")
 

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -216,7 +216,7 @@ def test_repo_dirty_handling(monkeypatch, tmp_path):
 
     repo = git.Repo(repo_path)
     # Messing with the init should make the repo "dirty"
-    assert repo.is_dirty() == True
+    assert repo.is_dirty() is True
 
     # And get_data should raise a ValueError as the repo is dirty
     with pytest.raises(ValueError):

--- a/ska_helpers/tests/test_chandra_models.py
+++ b/ska_helpers/tests/test_chandra_models.py
@@ -205,6 +205,29 @@ def test_get_model_file_fail():
         chandra_models.get_data(ACA_SPEC_PATH, repo_path="__NOT_A_DIRECTORY__")
 
 
+@pytest.mark.skipif(SOME_ENV_VAR_DEFINED, reason="Non flight repo is being used")
+def test_repo_dirty_handling(monkeypatch, tmp_path):
+    repo_path = tmp_path / "chandra_models"
+    default_root = Path(os.environ["SKA"], "data", "chandra_models")
+    git.Repo.clone_from(default_root, repo_path)
+    # Make a change to the repo
+    with open(repo_path / "chandra_models/__init__.py", "a") as fh:
+        fh.write("# test\n")
+
+    repo = git.Repo(repo_path)
+    # Messing with the init should make the repo "dirty"
+    assert repo.is_dirty() == True
+
+    # And get_data should raise a ValueError as the repo is dirty
+    with pytest.raises(ValueError):
+        _, info = chandra_models.get_data(ACA_SPEC_PATH, repo_path=repo_path)
+
+    # But no value error if the THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW env var is set
+    monkeypatch.setenv("THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW", str(repo_path))
+    _, info = chandra_models.get_data(ACA_SPEC_PATH, repo_path=repo_path)
+    assert info["repo_path"] == str(repo_path)
+
+
 def test_get_repo_version():
     version = chandra_models.get_repo_version()
     assert isinstance(version, str)


### PR DESCRIPTION
## Description
Skip is_dirty check from matlab tools.  The gitpython is_dirty appears to use a lock that touches files in the index.  This conflicts with SVN management of the chandra_models repo (and marks the repo as modified for matlab users).  That behavior is undesireable.  This PR skips the is_dirty check if THERMAL_MODELS_FOR_MATLAB_TOOLS_SW is set.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #44 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Made a new unit test for functional testing. 

I directly confirmed in matlab testing that using ska_helpers 0.10.3 and doing 'ska_helpers.chandra_models.get_data("chandra_models/xija/aca/aca_spec.json")'
marks the chandra_models-3.49 directory with an svn red exclamation mark, and doing the same operation with this branch in the pyexec python path does not (leaves it with the svn green check).
