### PR TITLE
Rename test so error isn't in the name

### DIFF
--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -148,6 +148,6 @@ def test_convert_to_int_float_str(value, type_, expected):
     assert type(out) is type_  # noqa: E721
 
 
-def test_convert_to_int_float_str_error():
+def test_convert_to_int_float_str_err():
     with pytest.raises(TypeError, match="input value must be a string, not float"):
         convert_to_int_float_str(1.05)


### PR DESCRIPTION
## Description

Rename test so error isn't in the name

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
It is easier just to rename the test than to handle this in ska_testr where we are currently not passing integration tests on ska_helpers with:
```
'error' matched at test_unit.log:50 :: ../../../../../../../ska_testr/tests/test
_utils.py::test_convert_to_int_float_str_error PASSED
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
