### PR TITLE
Suppress the setuptools_scm warning

### DIFF
--- a/ska_helpers/environment.py
+++ b/ska_helpers/environment.py
@@ -5,6 +5,7 @@ runtime environment at the point of import of every Ska3 package.
 """
 
 import os
+import warnings
 from functools import cache
 
 
@@ -26,3 +27,12 @@ def configure_ska_environment():
     # potentially including subdirectories.
     numba_cache_dir = os.path.join(os.path.expanduser("~"), ".ska3", "cache", "numba")
     os.environ.setdefault("NUMBA_CACHE_DIR", numba_cache_dir)
+
+    # Suppress warning when importing astropy_healpix in a git repo.
+    # https://github.com/astropy/astropy-healpix/issues/211
+    warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        message="git archive did not support describe output",
+        module="setuptools_scm",
+    )


### PR DESCRIPTION
## Description

This suppresses a warning that gets emitted any time you import `astropy_healpix` from within a git repo that has files for `scm_setuptools`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None, apart from suppressing that warning.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  ska_helpers git:(suppress-healpix-version-warning) git rev-parse HEAD                         
f9561666f4cb7149765aed42b18bfb9794ea686a
(ska3) ➜  ska_helpers git:(suppress-healpix-version-warning) pytest
=================================================== test session starts ====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 72 items                                                                                                         

ska_helpers/retry/tests/test_retry.py ..........                                                                     [ 13%]
ska_helpers/tests/test_chandra_models.py ..................                                                          [ 38%]
ska_helpers/tests/test_git_helpers.py s                                                                              [ 40%]
ska_helpers/tests/test_intervals.py .................                                                                [ 63%]
ska_helpers/tests/test_paths.py ......                                                                               [ 72%]
ska_helpers/tests/test_run_info.py ..                                                                                [ 75%]
ska_helpers/tests/test_utils.py ..................                                                                   [100%]

============================================== 71 passed, 1 skipped in 5.83s ===============================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Including this PR in the Python path fixes the problem as long as any Ska3 package is imported prior to the import of `astropy_healpix`.
```
(ska3) ➜  kadi git:(observations-from-cmds) cd ~/git/kadi           
(ska3) ➜  kadi git:(observations-from-cmds) python -c "import agasc"
/Users/aldcroft/miniconda3/envs/ska3/lib/python3.10/site-packages/setuptools_scm/git.py:295: UserWarning: git archive did not support describe output
  warnings.warn("git archive did not support describe output")
(ska3) ➜  kadi git:(observations-from-cmds) env PYTHONPATH=/Users/aldcroft/git/ska_helpers python -c "import agasc"
```
