### PR TITLE
Add TypedDescriptor class for typed descriptors

### DIFF
--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import pickle
 import time
@@ -9,7 +10,7 @@ from ska_helpers.utils import (
     LazyDict,
     LazyVal,
     LRUDict,
-    TypedDescriptorBase,
+    TypedDescriptor,
     convert_to_int_float_str,
     lru_cache_timed,
     temp_env_var,
@@ -155,14 +156,18 @@ def test_convert_to_int_float_str_err():
         convert_to_int_float_str(1.05)
 
 
-class IntDescriptor(TypedDescriptorBase):
+class IntDescriptor(TypedDescriptor):
     cls = int
 
 
-def test_int_descriptor_not_required_no_default():
+IntDescriptorFromKwargs = functools.partial(TypedDescriptor, cls=int)
+
+
+@pytest.mark.parametrize("cls_descriptor", [IntDescriptor, IntDescriptorFromKwargs])
+def test_int_descriptor_not_required_no_default(cls_descriptor):
     @dataclass
     class MyClass:
-        val_int: int | None = IntDescriptor()
+        val_int: int | None = cls_descriptor()
 
     obj = MyClass()
     assert obj.val_int is None
@@ -172,10 +177,11 @@ def test_int_descriptor_not_required_no_default():
     assert obj.val_int == 10
 
 
-def test_int_descriptor_is_required():
+@pytest.mark.parametrize("cls_descriptor", [IntDescriptor, IntDescriptorFromKwargs])
+def test_int_descriptor_is_required(cls_descriptor):
     @dataclass
     class MyClass:
-        val_int: int = IntDescriptor(required=True)
+        val_int: int = cls_descriptor(required=True)
 
     obj = MyClass(10.2)
     assert obj.val_int == 10
@@ -186,10 +192,11 @@ def test_int_descriptor_is_required():
         MyClass()
 
 
-def test_int_descriptor_has_default():
+@pytest.mark.parametrize("cls_descriptor", [IntDescriptor, IntDescriptorFromKwargs])
+def test_int_descriptor_has_default(cls_descriptor):
     @dataclass
     class MyClass:
-        val_int: int = IntDescriptor(default=10.5)
+        val_int: int = cls_descriptor(default=10.5)
 
     obj = MyClass()
     # Default of 10.5 is cast to int
@@ -199,11 +206,12 @@ def test_int_descriptor_has_default():
     assert obj.val_int == 3
 
 
-def test_int_descriptor_is_required_has_default_exception():
+@pytest.mark.parametrize("cls_descriptor", [IntDescriptor, IntDescriptorFromKwargs])
+def test_int_descriptor_is_required_has_default_exception(cls_descriptor):
     with pytest.raises(
         ValueError, match="cannot set both 'required' and 'default' arguments"
     ):
 
         @dataclass
         class MyClass:
-            quat: int = IntDescriptor(default=30, required=True)
+            quat: int = cls_descriptor(default=30, required=True)

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -373,8 +373,8 @@ def convert_to_int_float_str(val: str) -> int | float | str:
     return out
 
 
-class TypedDescriptorBase:
-    """Base class to create a descriptor for an attribute that is cast to a type.
+class TypedDescriptor:
+    """Class to create a descriptor for an attribute that is cast to a type.
 
     This is a base class for creating a descriptor that can be used to define an
     attribute on a class that is cast to a specific type.  The type is specified by
@@ -382,6 +382,9 @@ class TypedDescriptorBase:
 
     Most commonly ``cls`` is a class like ``CxoTime`` or ``Quat``, but it could also
     be a function like ``int`` or ``float``.
+
+    This descriptor can be used either as a base class with the ``cls`` class attribute
+    set accordingly, or as a decriptor with the ``cls`` keyword argument set.
 
     Parameters
     ----------
@@ -395,9 +398,22 @@ class TypedDescriptorBase:
     Examples
     --------
     >>> from dataclasses import dataclass
+    >>> from ska_helpers.utils import TypedDescriptor
+
+    Here we make a dataclass with an attribute that is cast to an int.
+
+    >>> @dataclass
+    >>> class SomeClass:
+    ...     int_val: int = TypedDescriptor(required=True, cls=int)
+    >>> obj = SomeClass(10.5)
+    >>> obj.int_val
+    10
+
+    Here we define a ``QuatDescriptor`` class that can be used repeatedly for any
+    quaternion attribute.
+
     >>> from Quaternion import Quat
-    >>> from ska_helpers.utils import TypedDescriptorBase
-    >>> class QuatDescriptor(TypedDescriptorBase):
+    >>> class QuatDescriptor(TypedDescriptor):
     ...     cls = Quat
     >>> @dataclass
     ... class MyClass:
@@ -417,9 +433,9 @@ class TypedDescriptorBase:
     array([10., 20., 30.])
     """
 
-    cls = None
-
-    def __init__(self, *, default=None, required=False):
+    def __init__(self, *, default=None, required=False, cls=None):
+        if cls is not None:
+            self.cls = cls
         if required and default is not None:
             raise ValueError("cannot set both 'required' and 'default' arguments")
         self.default = default if default is None else self.cls(default)

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -12,6 +12,7 @@ __all__ = [
     "lru_cache_timed",
     "temp_env_var",
     "convert_to_int_float_str",
+    "TypedDescriptor",
 ]
 
 

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -382,10 +382,10 @@ class TypedDescriptor:
     setting the ``cls`` class attribute on the descriptor class.
 
     Most commonly ``cls`` is a class like ``CxoTime`` or ``Quat``, but it could also
-    be a function like ``int`` or ``float``.
+    be a built-in like ``int`` or ``float`` or any callable function.
 
     This descriptor can be used either as a base class with the ``cls`` class attribute
-    set accordingly, or as a decriptor with the ``cls`` keyword argument set.
+    set accordingly, or as a descriptor with the ``cls`` keyword argument set.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

This provides a new generic descriptor class `TypedDescriptor` that can be used to easily make typed attributes in a dataclass (or a regular class). See https://github.com/sot/Quaternion/pull/44 for the prototype example.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new tests)

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Also used in new unit tests in https://github.com/sot/Quaternion/pull/44 and https://github.com/sot/cxotime/pull/43.
