### PR TITLE
Coerce TypedDescriptor default at instance creation 

### DIFF
--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -187,7 +187,12 @@ def test_int_descriptor_is_required(cls_descriptor):
     assert obj.val_int == 10
 
     with pytest.raises(
-        ValueError, match="cannot set required attribute 'val_int' to None"
+        ValueError, match="attribute 'val_int' is required and cannot be set to None"
+    ):
+        obj.val_int = None
+
+    with pytest.raises(
+        ValueError, match="attribute 'val_int' is required and cannot be set to None"
     ):
         MyClass()
 
@@ -197,6 +202,9 @@ def test_int_descriptor_has_default(cls_descriptor):
     @dataclass
     class MyClass:
         val_int: int = cls_descriptor(default=10.5)
+
+    # Accessing the class attribute returns original default value (used by dataclass).
+    assert MyClass.val_int == 10.5
 
     obj = MyClass()
     # Default of 10.5 is cast to int


### PR DESCRIPTION
## Description

This changes the `TypedDescriptor` behavior so that the `default` is only coerced to the type at the time of instance creation. This is important for the `CxoTimeDescriptor` in https://github.com/sot/cxotime/pull/43, but in general this lazy evaluation of the default is a good thing.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(razl) ➜  ska_helpers git:(typed-descriptor-lazy-default) git rev-parse HEAD                                                        
d7f2e189eb2fb46a30d3d801f125da1eacc3d0c8
(razl) ➜  ska_helpers git:(typed-descriptor-lazy-default) pytest
=========================================================================== test session starts ============================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 80 items                                                                                                                                                         

ska_helpers/retry/tests/test_retry.py ..........                                                                                                                     [ 12%]
ska_helpers/tests/test_chandra_models.py ..................                                                                                                          [ 35%]
ska_helpers/tests/test_git_helpers.py s                                                                                                                              [ 36%]
ska_helpers/tests/test_intervals.py .................                                                                                                                [ 57%]
ska_helpers/tests/test_paths.py ......                                                                                                                               [ 65%]
ska_helpers/tests/test_run_info.py ..                                                                                                                                [ 67%]
ska_helpers/tests/test_utils.py ..........................                                                                                                           [100%]

====================================================================== 79 passed, 1 skipped in 7.48s =======================================================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Tested also in https://github.com/sot/cxotime/pull/43. In particular the distinction between evaluation at instance creation vs. class creation is demonstrated there.
