### PR TITLE
New utils: logger context manager and random RA and Decs

### DIFF
--- a/ska_helpers/__init__.py
+++ b/ska_helpers/__init__.py
@@ -2,6 +2,7 @@
 """
 Ska_helpers is a collection of utilities for the Ska3 runtime environment.
 """
+
 from .version import get_version
 
 __version__ = get_version(__package__)

--- a/ska_helpers/chandra_models.py
+++ b/ska_helpers/chandra_models.py
@@ -2,6 +2,7 @@
 """
 Get data from chandra_models repository.
 """
+
 import contextlib
 import functools
 import hashlib

--- a/ska_helpers/git_helpers.py
+++ b/ska_helpers/git_helpers.py
@@ -2,6 +2,7 @@
 """
 Helper functions for using git.
 """
+
 import functools
 import git
 import re

--- a/ska_helpers/retry/__init__.py
+++ b/ska_helpers/retry/__init__.py
@@ -19,6 +19,7 @@ LICENSE::
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+
 __all__ = ["retry", "retry_call", "RetryError", "tables_open_file"]
 
 import logging

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -1,11 +1,15 @@
 import functools
+import logging
 import os
 import pickle
 import time
 from dataclasses import dataclass
 
+import agasc
+import numpy as np
 import pytest
 
+import ska_helpers.logging
 from ska_helpers.utils import (
     LazyDict,
     LazyVal,
@@ -13,12 +17,10 @@ from ska_helpers.utils import (
     TypedDescriptor,
     convert_to_int_float_str,
     lru_cache_timed,
+    random_radec_in_cone,
     set_log_level,
     temp_env_var,
 )
-
-import ska_helpers.logging
-import logging
 
 
 def load_func(a, b, c=None):
@@ -247,3 +249,23 @@ def test_set_log_level():
     assert len(logger.handlers) == 1
     for hdlr in logger.handlers:
         assert hdlr.level == 0
+
+
+def test_random_radec_in_cone_scalar():
+    np.random.seed(0)
+    ra, dec = random_radec_in_cone(10, 20, angle=5)
+    assert np.isclose(ra, 8.6733489)
+    assert np.isclose(dec, 15.964518)
+
+
+def test_random_radec_in_cone_size_values():
+    np.random.seed(0)
+    ra, dec = random_radec_in_cone(10, 20, angle=5, size=2)
+    assert np.allclose(ra, [8.77992603, 6.18623754])
+    assert np.allclose(dec, [16.29571322, 19.15880785])
+
+
+def test_random_radec_in_cone_size_angle():
+    np.random.seed(0)
+    ra, dec = random_radec_in_cone(10, 20, angle=5, size=10000)
+    assert np.all(agasc.sphere_dist(ra, dec, 10, 20) < 5)

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -13,8 +13,12 @@ from ska_helpers.utils import (
     TypedDescriptor,
     convert_to_int_float_str,
     lru_cache_timed,
+    set_log_level,
     temp_env_var,
 )
+
+import ska_helpers.logging
+import logging
 
 
 def load_func(a, b, c=None):
@@ -223,3 +227,15 @@ def test_int_descriptor_is_required_has_default_exception(cls_descriptor):
         @dataclass
         class MyClass:
             quat: int = cls_descriptor(default=30, required=True)
+
+
+def test_set_log_level():
+    logger = ska_helpers.logging.basic_logger("test_utils", level="DEBUG")
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) > 0
+    for hdlr in logger.handlers:
+        assert hdlr.level == 0
+    with set_log_level(logger, "INFO"):
+        assert logger.level == logging.INFO
+        for hdlr in logger.handlers:
+            assert hdlr.level == logging.INFO

--- a/ska_helpers/tests/test_utils.py
+++ b/ska_helpers/tests/test_utils.py
@@ -231,11 +231,19 @@ def test_int_descriptor_is_required_has_default_exception(cls_descriptor):
 
 def test_set_log_level():
     logger = ska_helpers.logging.basic_logger("test_utils", level="DEBUG")
+
     assert logger.level == logging.DEBUG
-    assert len(logger.handlers) > 0
+    assert len(logger.handlers) == 1
     for hdlr in logger.handlers:
         assert hdlr.level == 0
+
     with set_log_level(logger, "INFO"):
         assert logger.level == logging.INFO
+        assert len(logger.handlers) == 1
         for hdlr in logger.handlers:
             assert hdlr.level == logging.INFO
+
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    for hdlr in logger.handlers:
+        assert hdlr.level == 0

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -13,7 +13,35 @@ __all__ = [
     "temp_env_var",
     "convert_to_int_float_str",
     "TypedDescriptor",
+    "set_log_level",
 ]
+
+
+@contextlib.contextmanager
+def set_log_level(logger, level=None):
+    """Set the log level of a logger and its handlers for context block.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        The logger object to set the level for.
+    level : str, int, None, optional
+        The log level to set.  This can be a string like "DEBUG", "INFO", "WARNING",
+        "ERROR", "CRITICAL", or an integer value from the ``logging`` module. If level
+        is None (default), the log level is not changed.
+    """
+    orig_levels = {}
+    if level is not None:
+        orig_levels[logger] = logger.level
+        logger.setLevel(level)
+        for handler in logger.handlers:
+            orig_levels[handler] = handler.level
+            handler.setLevel(level)
+    try:
+        yield
+    finally:
+        for log_obj, orig_level in orig_levels.items():
+            log_obj.setLevel(orig_level)
 
 
 def get_owner(path):

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -6,6 +6,7 @@ import os
 from collections import OrderedDict
 
 __all__ = [
+    "get_owner",
     "LazyDict",
     "LazyVal",
     "LRUDict",

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -277,7 +277,7 @@ def lru_cache_timed(maxsize=128, typed=False, timeout=3600):
 
 
 def random_radec_in_cone(
-    ra: float, dec: float, angle: float, size=None
+    ra: float, dec: float, *, angle: float, size=None
 ) -> tuple[np.ndarray, np.ndarray]:
     """Get random sky coordinates within a cone.
 

--- a/ska_helpers/utils.py
+++ b/ska_helpers/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "convert_to_int_float_str",
     "TypedDescriptor",
     "set_log_level",
+    "random_radec_in_cone",
 ]
 
 


### PR DESCRIPTION
## Description

Add two new functions to `ska_helpers.utils`:
- `random_radec_in_cone()`: Get random sky coordinates within a cone.
- `set_log_level()`: Context manager to temporarily set the log level for a logger

This also includes ruff whitespace changes to four files.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds functions.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new test)
```
(ska3) ➜  ska_helpers git:(new-utils-logger-cm-random-ra-dec) git rev-parse HEAD 
f44f205935233cc45bfd74e5e8cfe957017c1e8a
(ska3) ➜  ska_helpers git:(new-utils-logger-cm-random-ra-dec) pytest
============================================== test session starts ==============================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 71 items                                                                                              

ska_helpers/retry/tests/test_retry.py ..............                                                      [ 19%]
ska_helpers/tests/test_chandra_models.py ..................                                               [ 45%]
ska_helpers/tests/test_git_helpers.py s                                                                   [ 46%]
ska_helpers/tests/test_paths.py ......                                                                    [ 54%]
ska_helpers/tests/test_run_info.py ..                                                                     [ 57%]
ska_helpers/tests/test_utils.py ..............................                                            [100%]

========================================= 70 passed, 1 skipped in 4.49s =========================================
```

Independent check of unit tests by Jean -
- [x] Linux
```
ska3-jeanconn-fido> pytest
========================================================== test session starts ===========================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 71 items                                                                                                                       

ska_helpers/retry/tests/test_retry.py ..............                                                                               [ 19%]
ska_helpers/tests/test_chandra_models.py ..................                                                                        [ 45%]
ska_helpers/tests/test_git_helpers.py .                                                                                            [ 46%]
ska_helpers/tests/test_paths.py ......                                                                                             [ 54%]
ska_helpers/tests/test_run_info.py ..                                                                                              [ 57%]
ska_helpers/tests/test_utils.py ..............................                                                                     [100%]

========================================================== 71 passed in 11.74s ===========================================================
ska3-jeanconn-fido> git rev-parse HEAD
2195a1cf683255cd31cc292063de603204c0d6b1
```
 I note if I use `pytest -vs` there is some output printed, that I would think would be a problem for ska_testr:
```
ska_helpers/retry/tests/test_retry.py::test_retry WARNING: f() exception: division by zero, retrying in 1 seconds...
```
but ska_testr isn't catching that in the log checks for whatever reason so seems fine (and not due to this PR anyway).

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
#### random_radec_in_code

Looks like a random and spatially-uniform distribution:
```
>>> from ska_helpers import utils
>>> ras, decs = utils.random_radec_in_cone(95, 5, 5, 500000)
>>> plt.plot(ras, decs, ",")
```
<img width="376" alt="image" src="https://github.com/user-attachments/assets/2108f59a-220c-4be8-8412-4d98490a27f9">
