### PR TITLE
Improve sphinx docs base conf.py

### DIFF
--- a/ska_helpers/docs/__init__.py
+++ b/ska_helpers/docs/__init__.py
@@ -2,27 +2,39 @@
 
 Example usage in docs/conf.py. This is available in ``skare3/templates/conf.py``::
 
-    import os
+  import ska_helpers.docs
+  
+  # Get variables from the ska_helpers.docs.conf module that are not private, modules, or
+  # classes and inject into this namespace. This provides the base configuration for the
+  # Sphinx documentation.
+  globals().update(
+      ska_helpers.docs.get_conf_module_vars(
+          project="chandra_aca",
+          author="Tom Aldcroft",
+      )
+  )
+  
+  # Add any custom configuration here
 
-    import ska_helpers.docs
-
-    context = {
-        "project": "parse_cm",
-        "author": "Tom Aldcroft",
-        "import_path": os.path.abspath(".."),
-    }
-
-    # Get the base Ska conf.py from ska_helpers.docs.conf, putting `context` into the
-    # conf.py namespace.
-    conf = ska_helpers.docs.get_conf_module(context)
-
-    # Inject all the symbols from the ska_helpers.docs.conf module into this namespace.
-    globals().update({k: v for k, v in vars(conf).items() if not k.startswith("_")})
 """
 import sys
 import importlib.util
+import inspect
 
 def get_conf_module(context):
+    """Return the ska_helpers.docs.conf module.
+
+    Parameters
+    ----------
+    context : dict
+        A dictionary of context variables to inject into the conf module.
+        This is typically the project name and author.
+
+    Returns
+    -------
+    module
+        The ska_helpers.docs.conf module with the context variables injected.
+    """
     name = "ska_helpers.docs.conf"
     spec = importlib.util.find_spec(name)
     conf = importlib.util.module_from_spec(spec)
@@ -33,3 +45,31 @@ def get_conf_module(context):
     sys.modules[name] = conf
     spec.loader.exec_module(conf)
     return conf
+
+
+def get_conf_module_vars(**context):
+    """Return the configuration variables from the ska_helpers.docs.conf module.
+
+    Parameters
+    ----------
+    context : dict
+        A dictionary of context variables to inject into the conf module.
+        This is typically the project name, author, and import path.
+        The import path is used to set the sys.path for the conf module.
+
+    Returns
+    -------
+    dict
+        A dictionary of variables from the ska_helpers.docs.conf module.
+        This includes the project name, author, and import path.
+    """
+    conf = get_conf_module(context)
+
+    # Extract the variables from the conf module that are not private, modules, or
+    # classes and return that as a dict.
+    vars_ = {
+        k: v
+        for k, v in vars(conf).items()
+        if not k.startswith("_") and not inspect.ismodule(v) and not inspect.isclass(v)
+    }
+    return vars_

--- a/ska_helpers/docs/conf.py
+++ b/ska_helpers/docs/conf.py
@@ -8,6 +8,7 @@
 import datetime
 import importlib
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -44,9 +45,11 @@ extensions = [
 
 templates_path = [template_dir]
 
-# Version information from the package.
+# Version information from the package. Clip anything in the version beyond dev number,
+# e.g. 0.1.0.dev12+g1234567+d12312311 => 0.1.0.dev12. This is to avoid the version
+# stomping on the top menu.
 pkg = importlib.import_module(project)
-version = pkg.__version__
+version = re.sub(r"(dev\d+).+", r"\1", pkg.__version__)
 release = version
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]


### PR DESCRIPTION
## Description

While using the machinery in `ska_helpers.docs` to update the `chandra_aca` docs, I thought of a way to reduce boilerplate code and implemented it here.

In addition, this PR truncates the package version so that it does not include the long SHA strings. E.g. during docs development the `chandra_aca` version could look like `'4.49.1.dev5+gee91a59.d20250404`. This overruns the allowed space for version in the HTML docs output and makes it hard to use the page. With this PR the version is truncated to `4.49.1dev5`. For a normal release version this has no impact.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a new function that reduces boilerplate in package `conf.py` files.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Used this with https://github.com/sot/chandra_aca/pull/190.
