### PR TITLE
Fix test_docs after #62

### DIFF
--- a/ska_helpers/tests/test_docs.py
+++ b/ska_helpers/tests/test_docs.py
@@ -1,6 +1,7 @@
 import ska_helpers
 from ska_helpers.docs import get_conf_module
 import os
+import re
 from pathlib import Path
 
 
@@ -17,5 +18,6 @@ def test_get_conf_module():
     assert conf.template_dir == str(
         Path(ska_helpers.docs.__file__).parent.absolute() / "_templates"
     )
-    assert conf.version == ska_helpers.__version__
-    assert conf.release == ska_helpers.__version__
+    version =re.sub(r"(dev\d+).+", r"\1", ska_helpers.__version__)
+    assert conf.version == version
+    assert conf.release == version

--- a/ska_helpers/tests/test_docs.py
+++ b/ska_helpers/tests/test_docs.py
@@ -18,6 +18,6 @@ def test_get_conf_module():
     assert conf.template_dir == str(
         Path(ska_helpers.docs.__file__).parent.absolute() / "_templates"
     )
-    version =re.sub(r"(dev\d+).+", r"\1", ska_helpers.__version__)
+    version = re.sub(r"(dev\d+).+", r"\1", ska_helpers.__version__)
     assert conf.version == version
     assert conf.release == version


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes test_docs.py::test_get_conf_module, which is failing with the following error after #62 

```
FAILED ska_helpers/tests/test_docs.py::test_get_conf_module - AssertionError: assert '0.18.1.dev3' == '0.18.1.dev3+gcb676d1'
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

```
~/SAO/git/ska_helpers fix-docs-version-test $ git rev-parse HEAD
c7f2e45f0102de4dc77dd7184310109e7d5b4494
~/SAO/git/ska_helpers fix-docs-version-test $ pytest ska_helpers 
=============================================================================================== test session starts ================================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 72 items                                                                                                                                                                                                 

ska_helpers/retry/tests/test_retry.py ..............                                                                                                                                                         [ 19%]
ska_helpers/tests/test_chandra_models.py ..................                                                                                                                                                  [ 44%]
ska_helpers/tests/test_docs.py .                                                                                                                                                                             [ 45%]
ska_helpers/tests/test_git_helpers.py s                                                                                                                                                                      [ 47%]
ska_helpers/tests/test_paths.py ......                                                                                                                                                                       [ 55%]
ska_helpers/tests/test_run_info.py ..                                                                                                                                                                        [ 58%]
ska_helpers/tests/test_utils.py ..............................                                                                                                                                               [100%]

========================================================================================== 71 passed, 1 skipped in 8.01s ===========================================================================================

```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
