### PR TITLE
Improve retry functionality in a few ways

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.2.1
+  rev: v0.14.3
   hooks:
     # Run the linter.
     - id: ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -45,6 +45,8 @@ lint.ignore = [
   "PLR0913", # Too many arguments to function call
   "PLR0915", # Too many statements
   "PLR2004", # Magic number
+  "PLC0415", # import at top level
+  "PLW1641", # Object does not implement `__hash__` method
 ]
 
 # TODO : fix these and stop ignoring. Commented out ones are common and OK to except.

--- a/ska_helpers/retry/__init__.py
+++ b/ska_helpers/retry/__init__.py
@@ -20,12 +20,10 @@ LICENSE::
     limitations under the License.
 """
 
-__all__ = ["retry", "retry_call", "RetryError", "tables_open_file", "MockFuncFailure"]
-
 import logging
 from logging import StreamHandler
 
-from .api import MockFuncFailure, RetryError, retry, retry_call, tables_open_file
+from .api import *
 
 log = logging.getLogger(__name__)
 log.addHandler(StreamHandler())

--- a/ska_helpers/retry/__init__.py
+++ b/ska_helpers/retry/__init__.py
@@ -20,12 +20,12 @@ LICENSE::
     limitations under the License.
 """
 
-__all__ = ["retry", "retry_call", "RetryError", "tables_open_file"]
+__all__ = ["retry", "retry_call", "RetryError", "tables_open_file", "MockFuncFailure"]
 
 import logging
 from logging import StreamHandler
 
-from .api import RetryError, retry, retry_call, tables_open_file
+from .api import MockFuncFailure, RetryError, retry, retry_call, tables_open_file
 
 log = logging.getLogger(__name__)
 log.addHandler(StreamHandler())

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -4,6 +4,7 @@ import re
 import sys
 import time
 import traceback
+from dataclasses import dataclass, field
 
 from ska_helpers.logging import basic_logger
 
@@ -21,6 +22,36 @@ class RetryError(Exception):
 
     def __init__(self, failures):
         self.failures = failures
+
+
+@dataclass
+class MockFuncFailure:
+    """Mock a function ``func`` to fail ``n_fail`` times and then succeed.
+
+    Example::
+
+        def test_stk_ephem_timeout(monkeypatch):
+            mock_get_occ_web_page = MockFuncFailure(occweb.get_occweb_page, n_fail=1)
+            monkeypatch.setattr(occweb, "get_occweb_page", mock_get_occ_web_page)
+            fetch_cxc.Msid("orbitephem_stk_x", "2023:001", "2023:002")
+            successes = [call["success"] for call in mock_get_occ_web_page.calls]
+            assert successes == [False, True, False, True]
+    """
+
+    func: callable
+    calls: list[dict] = field(default_factory=list)
+    n_fail: int = 2
+
+    def __call__(self, *args, **kwargs):
+        call = {"args": args, "kwargs": kwargs}
+        self.calls.append(call)
+
+        count = len(self.calls)
+        if count % (self.n_fail + 1) != 0:
+            call["success"] = False
+            raise TimeoutError("mock timeout error")
+        call["success"] = True
+        return self.func(*args, **kwargs)
 
 
 def _mangle_alert_words(msg):

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -177,8 +177,7 @@ def __retry_internal(
                 )
                 if mangle_alert_words:
                     msg = _mangle_alert_words(msg)
-                print(logger)
-                logger.warning(msg, stacklevel=3)
+                logger.warning(msg)
 
             time.sleep(_delay)
             _delay *= backoff

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -1,4 +1,6 @@
 import functools
+import inspect
+import logging
 import random
 import re
 import sys
@@ -8,7 +10,16 @@ from dataclasses import dataclass, field
 
 from ska_helpers.logging import basic_logger
 
-logging_logger = basic_logger(__name__, format="%(message)s")
+__all__ = [
+    "retry",
+    "retry_call",
+    "retry_func",
+    "RetryError",
+    "tables_open_file",
+    "MockFuncFailure",
+]
+
+logging_logger = basic_logger(__name__)
 
 
 class RetryError(Exception):
@@ -28,19 +39,41 @@ class RetryError(Exception):
 class MockFuncFailure:
     """Mock a function ``func`` to fail ``n_fail`` times and then succeed.
 
-    Example::
+    This can be used to confirm that retry logic deep inside another package (e.g.
+    cheta or kadi) is working as expected. The key here is that this forces some
+    failures but then returns the real function result.
 
-        def test_stk_ephem_timeout(monkeypatch):
+    Examples::
+
+        from ska_helpers import retry
+        from kadi import occweb
+
+        # For pytest unit tests
+        def test_stk_ephem_timeout(monkeypatch, tmp_path, clear_lru_cache):
+            monkeypatch.setattr(
+                ephem_stk, "EPHEM_STK_CACHE_DIR_DEFAULT", str(tmp_path / "cache")
+            )
             mock_get_occ_web_page = MockFuncFailure(occweb.get_occweb_page, n_fail=1)
             monkeypatch.setattr(occweb, "get_occweb_page", mock_get_occ_web_page)
-            fetch_cxc.Msid("orbitephem_stk_x", "2023:001", "2023:002")
-            successes = [call["success"] for call in mock_get_occ_web_page.calls]
-            assert successes == [False, True, False, True]
+            result = fetch_cxc.Msid("orbitephem_stk_x", "2023:001", "2023:002")
+            assert result.MSID == "ORBITEPHEM_STK_X"
+            assert len(mock_get_occ_web_page.calls) >= 6
+
+        # For playing around in a notebook
+        from unittest.mock import patch
+        from cheta import fetch
+
+        mock_get_occ_web_page = retry.MockFuncFailure(occweb.get_occweb_page, n_fail=2)
+        with patch.object(occweb, "get_occweb_page", side_effect=mock_get_occ_web_page):
+            fetch.Msid("orbitephem_stk_x", "2023:001", "2023:002")
+        successes = [call["success"] for call in mock_get_occ_web_page.calls]
+        assert successes == [False, True, False, True]
     """
 
     func: callable
-    calls: list[dict] = field(default_factory=list)
     n_fail: int = 2
+    calls: list[dict] = field(default_factory=list)
+    exception_cls: type = TimeoutError
 
     def __call__(self, *args, **kwargs):
         call = {"args": args, "kwargs": kwargs}
@@ -49,9 +82,18 @@ class MockFuncFailure:
         count = len(self.calls)
         if count % (self.n_fail + 1) != 0:
             call["success"] = False
-            raise TimeoutError("mock timeout error")
+            raise self.exception_cls(
+                f"mock exception {self.exception_cls.__name__} #{count}"
+            )
         call["success"] = True
         return self.func(*args, **kwargs)
+
+    @property
+    def __name__(self):
+        return "mock-" + self.func.__name__
+
+    def __hash__(self) -> int:
+        return id(self)
 
 
 def _mangle_alert_words(msg):
@@ -146,7 +188,8 @@ def __retry_internal(
                 )
                 if mangle_alert_words:
                     msg = _mangle_alert_words(msg)
-                logger.warning(msg)
+                print(logger)
+                logger.warning(msg, stacklevel=3)
 
             time.sleep(_delay)
             _delay *= backoff
@@ -160,9 +203,53 @@ def __retry_internal(
                 _delay = min(_delay, max_delay)
 
 
+RETRY_DEFAULTS = {"tries": 3, "delay": 1, "backoff": 2, "mangle_alert_words": True}
+
+
+@functools.cache
+def retry_func(func, logger=..., **retry_kwargs):
+    """Wrap function with retry decorator using reasonable defaults.
+
+    The defaults are defined in RETRY_DEFAULTS::
+
+        {"tries": 3, "delay": 1, "backoff": 2, "mangle_alert_words": True}
+
+    If a logger is not provided, will attempt to get from caller's global 'logger'.
+
+    The output is cached for performance and so that multiple calls return the same
+    function.
+
+    Parameters
+    ----------
+    func : callable
+        Function to retry.
+    logger : Logger, optional
+        Logger to use. If not supplied, will attempt to get from caller's global 'logger'.
+        Set logger=None to disable this.
+    **retry_kwargs
+        Additional keyword arguments passed to the retry decorator, including overriding
+        the RETRY_DEFAULTS settings.
+
+    Returns
+    -------
+    callable
+        Wrapped function that will be retried.
+    """
+    retry_kwargs = RETRY_DEFAULTS | retry_kwargs
+    if logger is ...:
+        frame = inspect.currentframe().f_back  # Caller's frame
+        logger = frame.f_globals.get("logger")
+        del frame  # Avoid reference cycles with frames
+
+    if isinstance(logger, logging.Logger):
+        retry_kwargs = retry_kwargs | {"logger": logger}
+
+    return retry(**retry_kwargs)(func)
+
+
 def retry(
     exceptions=Exception,
-    tries=-1,
+    tries=3,
     delay=0,
     max_delay=None,
     backoff=1,
@@ -213,7 +300,7 @@ def retry_call(
     args=None,
     kwargs=None,
     exceptions=Exception,
-    tries=-1,
+    tries=3,
     delay=0,
     max_delay=None,
     backoff=1,

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -43,31 +43,20 @@ class MockFuncFailure:
     cheta or kadi) is working as expected. The key here is that this forces some
     failures but then returns the real function result.
 
-    Examples::
+    See `cheta.tests.test_comps.test_stk_ephem_timeout()` for an example usage.
 
-        from ska_helpers import retry
-        from kadi import occweb
-
-        # For pytest unit tests
-        def test_stk_ephem_timeout(monkeypatch, tmp_path, clear_lru_cache):
-            monkeypatch.setattr(
-                ephem_stk, "EPHEM_STK_CACHE_DIR_DEFAULT", str(tmp_path / "cache")
-            )
-            mock_get_occ_web_page = MockFuncFailure(occweb.get_occweb_page, n_fail=1)
-            monkeypatch.setattr(occweb, "get_occweb_page", mock_get_occ_web_page)
-            result = fetch_cxc.Msid("orbitephem_stk_x", "2023:001", "2023:002")
-            assert result.MSID == "ORBITEPHEM_STK_X"
-            assert len(mock_get_occ_web_page.calls) >= 6
-
-        # For playing around in a notebook
-        from unittest.mock import patch
-        from cheta import fetch
-
-        mock_get_occ_web_page = retry.MockFuncFailure(occweb.get_occweb_page, n_fail=2)
-        with patch.object(occweb, "get_occweb_page", side_effect=mock_get_occ_web_page):
-            fetch.Msid("orbitephem_stk_x", "2023:001", "2023:002")
-        successes = [call["success"] for call in mock_get_occ_web_page.calls]
-        assert successes == [False, True, False, True]
+    Parameters
+    ----------
+    func : callable
+        The function to mock.
+    n_fail : int, optional
+        The number of times to fail before succeeding. Default is 2.
+    calls : list of dict, optional
+        A list to record the calls made to the function. Each call is recorded
+        as a dictionary with keys 'args', 'kwargs', and 'success'. Default is an empty
+        list.
+    exception_cls : type, optional
+        The exception class to raise on failure. Default is TimeoutError.
     """
 
     func: callable

--- a/ska_helpers/retry/tests/test_retry.py
+++ b/ska_helpers/retry/tests/test_retry.py
@@ -13,8 +13,20 @@ import time
 import pytest
 import tables
 
-from ska_helpers.retry import RetryError, retry, tables_open_file
+from ska_helpers.retry import RetryError, retry, tables_open_file, MockFuncFailure
 from ska_helpers.retry.api import _mangle_alert_words, retry_call
+
+
+def test_mock_func_failure():
+    def func(x):
+        return x
+
+    mock_func = MockFuncFailure(func, n_fail=4)
+
+    out = retry_call(mock_func, [3], tries=5)
+    successes = [call["success"] for call in mock_func.calls]
+    assert successes == [False] * 4 + [True]
+    assert out == 3
 
 
 def test_retry(monkeypatch):

--- a/ska_helpers/retry/tests/test_retry.py
+++ b/ska_helpers/retry/tests/test_retry.py
@@ -300,7 +300,7 @@ class MockLogger:
     statement.
     """
 
-    def warning(self, msg, stacklevel=None):
+    def warning(self, msg):
         print(msg)
 
 

--- a/ska_helpers/retry/tests/test_retry.py
+++ b/ska_helpers/retry/tests/test_retry.py
@@ -1,19 +1,17 @@
-try:
-    from unittest.mock import create_autospec
-except ImportError:
-    from mock import create_autospec  # noqa
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
-
 import time
+from unittest.mock import MagicMock
 
 import pytest
 import tables
 
-from ska_helpers.retry import RetryError, retry, tables_open_file, MockFuncFailure
+from ska_helpers.logging import basic_logger
+from ska_helpers.retry import (
+    MockFuncFailure,
+    RetryError,
+    retry,
+    retry_func,
+    tables_open_file,
+)
 from ska_helpers.retry.api import _mangle_alert_words, retry_call
 
 
@@ -22,11 +20,38 @@ def test_mock_func_failure():
         return x
 
     mock_func = MockFuncFailure(func, n_fail=4)
+    assert mock_func.__name__ == "mock-func"
 
-    out = retry_call(mock_func, [3], tries=5)
+    out = retry_func(mock_func, tries=5, delay=0.01)(3)
     successes = [call["success"] for call in mock_func.calls]
     assert successes == [False] * 4 + [True]
     assert out == 3
+
+
+def test_retry_func(caplog):
+    def func42():
+        return 42
+
+    # Need to make a logger for this test that propagates to root so that caplog works.
+    logger = basic_logger("test_retry_func", level="WARNING")
+    logger.propagate = True
+
+    mock_func42 = MockFuncFailure(func42, n_fail=2)
+    result = retry_func(mock_func42, delay=0.01, logger=logger)()
+    assert len(mock_func42.calls) == 3  # 2 failures + 1 success
+    assert result == 42
+
+    # Test that warnings were logged for each retry
+    records = list(caplog.records)
+    assert len(records) == 2  # 2 failures before success
+    for record in records:
+        assert record.levelname == "WARNING"
+        assert (
+            "WARN1NG: mock-func42() excepti0n: mock excepti0n TimeoutErr0r"
+            in record.message
+        )
+    assert "retrying in 0.01 seconds..." in records[0].message
+    assert "retrying in 0.02 seconds..." in records[1].message
 
 
 def test_retry(monkeypatch):
@@ -275,7 +300,7 @@ class MockLogger:
     statement.
     """
 
-    def warning(self, msg):
+    def warning(self, msg, stacklevel=None):
         print(msg)
 
 

--- a/ska_helpers/retry/tests/test_retry.py
+++ b/ska_helpers/retry/tests/test_retry.py
@@ -11,8 +11,9 @@ from ska_helpers.retry import (
     retry,
     retry_func,
     tables_open_file,
+    retry_call,
 )
-from ska_helpers.retry.api import _mangle_alert_words, retry_call
+from ska_helpers.retry.api import _mangle_alert_words
 
 # Need to make a logger for this test that propagates to root so that caplog works.
 logger = basic_logger(__name__, propagate=True)

--- a/ska_helpers/retry/tests/test_retry.py
+++ b/ska_helpers/retry/tests/test_retry.py
@@ -14,6 +14,9 @@ from ska_helpers.retry import (
 )
 from ska_helpers.retry.api import _mangle_alert_words, retry_call
 
+# Need to make a logger for this test that propagates to root so that caplog works.
+logger = basic_logger(__name__, propagate=True)
+
 
 def test_mock_func_failure():
     def func(x):
@@ -28,16 +31,14 @@ def test_mock_func_failure():
     assert out == 3
 
 
-def test_retry_func(caplog):
+@pytest.mark.parametrize("default_logger", [True, False])
+def test_retry_func(caplog, default_logger):
     def func42():
         return 42
 
-    # Need to make a logger for this test that propagates to root so that caplog works.
-    logger = basic_logger("test_retry_func", level="WARNING")
-    logger.propagate = True
-
     mock_func42 = MockFuncFailure(func42, n_fail=2)
-    result = retry_func(mock_func42, delay=0.01, logger=logger)()
+    kwargs = {} if default_logger else {"logger": logger}
+    result = retry_func(mock_func42, delay=0.01, **kwargs)()
     assert len(mock_func42.calls) == 3  # 2 failures + 1 success
     assert result == 42
 
@@ -291,45 +292,32 @@ class MockTableOpen:
             return "SUCCESS"
 
 
-class MockLogger:
-    """Mock logger that just prints the message.
-
-    Insanely enough, pytest capsys does not capture logger warnings, not does caplog
-    capture those warnings. There are years-old GH issues open on this and it seems like
-    it won't get fixed. After wasting 1/2 hour on this I'm just going to use a print
-    statement.
-    """
-
-    def warning(self, msg):
-        print(msg)
-
-
-def test_tables_open_file_warning_with_mangle_alert_words(monkeypatch, capsys):
+def test_tables_open_file_warning_with_mangle_alert_words(monkeypatch, caplog):
     mock_table_open = MockTableOpen(2)
     monkeypatch.setattr(tables, "open_file", mock_table_open)
-    logger = MockLogger()
     h5 = tables_open_file("junk.h5", retry_delay=0.01, retry_logger=logger)
     assert h5 == "SUCCESS"
-    out = capsys.readouterr().out.lower()
-    for word in ["warning", "error", "exception", "fatal", "fail"]:
-        assert word not in out
-    for word in ["warn1ng", "err0r", "excepti0n", "fata1", "fai1"]:
-        assert word in out
+    for record in caplog.records:
+        msg = record.message.lower()
+        for word in ["warning", "error", "exception", "fatal", "fail"]:
+            assert word not in msg
+        for word in ["warn1ng", "err0r", "excepti0n", "fata1", "fai1"]:
+            assert word in msg
 
 
-def test_tables_open_file_warning_without_mangle_alert_words(monkeypatch, capfd):
+def test_tables_open_file_warning_without_mangle_alert_words(monkeypatch, caplog):
     mock_table_open = MockTableOpen(2)
     monkeypatch.setattr(tables, "open_file", mock_table_open)
-    logger = MockLogger()
     h5 = tables_open_file(
         "junk.h5", retry_delay=0.01, mangle_alert_words=False, retry_logger=logger
     )
     assert h5 == "SUCCESS"
-    out = capfd.readouterr().out.lower()
-    for word in ["warning", "error", "exception", "fatal", "fail"]:
-        assert word in out
-    for word in ["warn1ng", "err0r", "excepti0n", "fata1", "fai1"]:
-        assert word not in out
+    for record in caplog.records:
+        msg = record.message.lower()
+        for word in ["warning", "error", "exception", "fatal", "fail"]:
+            assert word in msg
+        for word in ["warn1ng", "err0r", "excepti0n", "fata1", "fai1"]:
+            assert word not in msg
 
 
 def test_tables_open_file_exception_with_mangle_alert_words(monkeypatch):


### PR DESCRIPTION
## Description

This addresses some shortcomings in the `ska_helpers.retry` module along with general improvements:
- Add MockFuncFailure class to help testing retries in other modules.
- Add `retry_func` for more convenient wrapping of functions.
- Update the default `tries` from `-1` (infinite retries) to `3`.
- Define `__all__` in a more typical way and use this in the package `__init__.py` import.
- Clean up some cruft in the test module (I figured out how to use the pytest `caplog`).

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Retry defaults are changed, but no code in Ska was using the default since it was useless.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  ska_helpers git:(add-mock-func-failure-class) git rev-parse --short HEAD
92558a6
(ska3) ➜  ska_helpers git:(add-mock-func-failure-class) pytest
========================================== test session starts ==========================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 75 items                                                                                      

ska_helpers/retry/tests/test_retry.py .................                                           [ 22%]
ska_helpers/tests/test_chandra_models.py ..................                                       [ 46%]
ska_helpers/tests/test_docs.py .                                                                  [ 48%]
ska_helpers/tests/test_git_helpers.py s                                                           [ 49%]
ska_helpers/tests/test_paths.py ......                                                            [ 57%]
ska_helpers/tests/test_run_info.py ..                                                             [ 60%]
ska_helpers/tests/test_utils.py ..............................                                    [100%]

===================================== 74 passed, 1 skipped in 5.49s =====================================
```
Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-kady> pytest
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 75 items                                                                                                                    

ska_helpers/retry/tests/test_retry.py .................                                                                         [ 22%]
ska_helpers/tests/test_chandra_models.py ..................                                                                     [ 46%]
ska_helpers/tests/test_docs.py .                                                                                                [ 48%]
ska_helpers/tests/test_git_helpers.py .                                                                                         [ 49%]
ska_helpers/tests/test_paths.py ......                                                                                          [ 57%]
ska_helpers/tests/test_run_info.py ..                                                                                           [ 60%]
ska_helpers/tests/test_utils.py ..............................                                                                  [100%]

========================================================= 75 passed in 14.11s =========================================================
ska3-jeanconn-kady> git rev-parse HEAD
92558a6ceac02f506ead364327a75dc4204b321b
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Some functional testing in related testing:
- https://github.com/sot/kadi/pull/366
- https://github.com/sot/cheta/pull/283
