### PR TITLE
Hide retry func kwarg values in logging, change mangle_alert_words default, change log level

### DIFF
--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -121,7 +121,7 @@ def __retry_internal(
     backoff=1,
     jitter=0,
     logger=logging_logger,
-    mangle_alert_words=False,
+    mangle_alert_words=True,
     args=None,
     kwargs=None,
 ):
@@ -242,7 +242,7 @@ def retry(
     backoff=1,
     jitter=0,
     logger=logging_logger,
-    mangle_alert_words=False,
+    mangle_alert_words=True,
 ):
     """Returns a retry decorator.
 
@@ -256,7 +256,7 @@ def retry(
     :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                    default: retry.logging_logger. if None, logging is disabled.
     :param mangle_alert_words: if True, mangle alert words "warning", "error", "fatal",
-                   "exception" when issuing a logger warning message. Default: False.
+                   "exception" when issuing a logger warning message. Default: True.
     :returns: a retry decorator.
     """
 
@@ -293,7 +293,7 @@ def retry_call(
     backoff=1,
     jitter=0,
     logger=logging_logger,
-    mangle_alert_words=False,
+    mangle_alert_words=True,
 ):
     """
     Calls a function and re-executes it if it failed.
@@ -312,7 +312,7 @@ def retry_call(
                    default: retry.logging_logger. if None, logging is disabled.
     :param mangle_alert_words: if True, mangle alert words "warning", "error", "fatal",
                    "exception", "fail" when issuing a logger warning message.
-                   Default: False.
+                   Default: True.
     :returns: the result of the f function.
     """
     if args is None:

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -176,7 +176,7 @@ def __retry_internal(
                 )
                 if mangle_alert_words:
                     msg = _mangle_alert_words(msg)
-                logger.warning(msg)
+                logger.info(msg)
 
             time.sleep(_delay)
             _delay *= backoff

--- a/ska_helpers/retry/api.py
+++ b/ska_helpers/retry/api.py
@@ -165,9 +165,8 @@ def __retry_internal(
                     raise
 
             if logger is not None:
-                call_args = list(args)
-                for key, val in kwargs.items():
-                    call_args.append(f"{key}={val}")
+                # Do not show kwarg values since they might include a password
+                call_args = list(args) + [f"{key}=..." for key in kwargs]
                 call_args_str = ", ".join(str(arg) for arg in call_args)
                 func_name = getattr(f, "__name__", "func")
                 func_call = f"{func_name}({call_args_str})"

--- a/ska_helpers/retry/tests/test_retry.py
+++ b/ska_helpers/retry/tests/test_retry.py
@@ -47,7 +47,7 @@ def test_retry_func(caplog, default_logger):
     records = list(caplog.records)
     assert len(records) == 2  # 2 failures before success
     for record in records:
-        assert record.levelname == "WARNING"
+        assert record.levelname == "INFO"
         assert (
             "WARN1NG: mock-func42() excepti0n: mock excepti0n TimeoutErr0r"
             in record.message


### PR DESCRIPTION
## Description

Ska testr integration testing showed an issue that sparked a conversation leading to some changes:

- Credentials were being leaked in the retry logging message. This PR prevents that from happening.
- Set the `mangle_alert_words` default to `True` in all functions and the decorator. This is generally what we want.
- Set the logging level for retry messages to INFO so they are visible in cron job outputs but not users. 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
- Changes the `mangle_alert_words` default to `True`
- Changes the logging message content.
- Change the retry logging level from WARNING to INFO.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  ska_helpers git:(fix-credentials-leak-in-logging) git rev-parse --short HEAD
85d9e3f
(ska3) ➜  ska_helpers git:(fix-credentials-leak-in-logging) pytest
============================================ test session starts =============================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 75 items                                                                                           

ska_helpers/retry/tests/test_retry.py .................                                                [ 22%]
ska_helpers/tests/test_chandra_models.py ..................                                            [ 46%]
ska_helpers/tests/test_docs.py .                                                                       [ 48%]
ska_helpers/tests/test_git_helpers.py s                                                                [ 49%]
ska_helpers/tests/test_paths.py ......                                                                 [ 57%]
ska_helpers/tests/test_run_info.py ..                                                                  [ 60%]
ska_helpers/tests/test_utils.py ..............................                                         [100%]

======================================= 74 passed, 1 skipped in 5.96s ========================================
```

Independent check of unit tests by Jean
- [x] OSX
```
(latest) flame:ska_helpers jean$ git rev-parse HEAD
85d9e3f47c2e576a40a0ad08d857f3425fcc6d95
(latest) flame:ska_helpers jean$ pytest
================================================ test session starts =================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 75 items                                                                                                   

ska_helpers/retry/tests/test_retry.py .................                                                        [ 22%]
ska_helpers/tests/test_chandra_models.py ..................                                                                       [ 46%]
ska_helpers/tests/test_docs.py .                                                                                                  [ 48%]
ska_helpers/tests/test_git_helpers.py s                                                                                           [ 49%]
ska_helpers/tests/test_paths.py ......                                                                                            [ 57%]
ska_helpers/tests/test_run_info.py ..                                                                                             [ 60%]
ska_helpers/tests/test_utils.py ..............................                                                                    [100%]

===================================================== 74 passed, 1 skipped in 8.63s
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
JC also ran the maude tests with output on and confirmed the kwargs aren't visible there:
```
maude/tests/test_maude.py::test_maude_retries 2025-11-19 11:49:50,111 __retry_internal: WARN1NG: get(http://telemetry.cfa.harvard.edu/maude/mrest/FLIGHT/msid.bin?m=CVCDUCTR&ts=2025313164949822&tp=2025323164949823&ap=t, timeout=..., headers=..., auth=...) excepti0n: HTTPSConnectionPool(host='telemetry.cfa.harvard.edu', port=443): Read timed out. (read timeout=0.1), retrying in 2.0 seconds...
2025-11-19 11:49:52,425 __retry_internal: WARN1NG: get(http://telemetry.cfa.harvard.edu/maude/mrest/FLIGHT/msid.bin?m=CVCDUCTR&ts=2025313164949822&tp=2025323164949823&ap=t, timeout=..., headers=..., auth=...) excepti0n: HTTPSConnectionPool(host='telemetry.cfa.harvard.edu', port=443): Read timed out. (read timeout=0.1), retrying in 2.0 seconds...
2025-11-19 11:49:54,723 __retry_internal: WARN1NG: get(http://telemetry.cfa.harvard.edu/maude/mrest/FLIGHT/msid.bin?m=CVCDUCTR&ts=2025313164949822&tp=2025323164949823&ap=t, timeout=..., headers=..., auth=...) excepti0n: HTTPSConnectionPool(host='telemetry.cfa.harvard.edu', port=443): Read timed out. (read timeout=0.1), retrying in 2.0 seconds...
PASSED
```